### PR TITLE
Rewrite using modified B+Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ list = list.insertAfter(null, { bunchId: "user1", counter: 0 }, 5);
 // Inserts 5 ids with bunchId="user1" and counters 0, 1, 2, 3, 4
 ```
 
-### Persistence
+#### Save and load
 
-Save and restore the list state:
+Save and load the list state in JSON form:
 
 ```typescript
 // Save list state
 const savedState = list.save();
 
-// Later, restore from saved state
+// Later, load from saved state
 let newList = IdList.load(savedState);
 ```
 
@@ -104,3 +104,11 @@ let newList = IdList.load(savedState);
 - Todo lists with collaborative editing
 - Any list where elements' positions change but need stable identifiers
 - Conflict-free replicated data type (CRDT) implementations
+
+## Performance
+
+### Asymptotics
+
+IdList stores its state as a modified [B+Tree](https://en.wikipedia.org/wiki/B%252B_tree), described at the top of [its source code](./src/id_list.ts). Each leaf in the B+Tree represents multiple ids in a compressed way; for normal collaborative text editing, expect 10-20 ElementIds per leaf.
+
+In terms of the number of leaves `L`, mutating an IdList with insertAfter/insertBefore/delete/undelete will only create `O(log(L))` new tree nodes, reusing the rest. However, most methods currently take `O(L)` total time because they search the whole tree for a given id, which has not yet been optimized (it uses a simple depth-first search). Exception: `IdList.at(index)` takes only `O(log(L))` time.

--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ import { IdList } from "articulated";
 // Create an empty list.
 let list = IdList.new();
 
-// Insert a new element at the beginning.
+// Insert a new ElementId at the beginning.
 // Note: Persistent (immutable) data structure! Mutators return a new IdList.
 list = list.insertAfter(null, { bunchId: "user1", counter: 0 });
 
-// Insert another element after the first.
+// Insert another ElementId after the first.
 list = list.insertAfter(
   { bunchId: "user1", counter: 0 },
   { bunchId: "user1", counter: 1 }
 );
 
-// Delete an element (marks as deleted but keeps as known).
+// Delete an ElementId (marks as deleted but keeps as known).
 list = list.delete({ bunchId: "user1", counter: 0 });
 
-// Check if elements are present/known.
+// Check if ElementIds are present/known.
 console.log(list.has({ bunchId: "user1", counter: 0 })); // false (deleted)
 console.log(list.isKnown({ bunchId: "user1", counter: 0 })); // true (known but deleted)
 ```
@@ -51,9 +51,9 @@ console.log(list.isKnown({ bunchId: "user1", counter: 0 })); // true (known but 
 An `ElementId` is a globally unique identifier for a list element, composed of:
 
 - `bunchId`: A string UUID or similar globally unique ID
-- `counter`: A numeric value to distinguish elements in the same bunch
+- `counter`: A numeric value to distinguish ElementIds in the same bunch
 
-For optimal compression, when inserting multiple elements in sequence, use the same `bunchId` with sequential `counter` values.
+For optimal compression, when inserting multiple ElementIds in a left-to-right sequence, use the same `bunchId` with sequential `counter` values.
 
 ```typescript
 // Example of IDs that will compress well
@@ -68,15 +68,15 @@ To enable easy and efficient rollbacks, such as in a [server reconciliation](htt
 
 #### Basic Operations
 
-- `insertAfter(before, newId): IdList`: Insert after a specific element
-- `insertBefore(after, newId): IdList`: Insert before a specific element
-- `delete(id): IdList`: Mark an element as deleted (remains known)
-- `undelete(id): IdList`: Restore a deleted element
+- `insertAfter(before, newId): IdList`: Insert after a specific ElementId
+- `insertBefore(after, newId): IdList`: Insert before a specific ElementId
+- `delete(id): IdList`: Mark an ElementId as deleted (remains known)
+- `undelete(id): IdList`: Restore a deleted ElementId
 
 #### Basic Accessors
 
-- `at(index)`: Get the element ID at a specific index
-- `indexOf(id, bias)`: Get the index of an element with optional bias for deleted elements
+- `at(index)`: Get the ElementId at a specific index
+- `indexOf(id, bias: "none" | "left" | "right" = "none")`: Get the index of an ElementId, with optional bias for deleted-but-known ElementIds
 
 #### Bulk Operations
 
@@ -105,10 +105,12 @@ let newList = IdList.load(savedState);
 - Any list where elements' positions change but need stable identifiers
 - Conflict-free replicated data type (CRDT) implementations
 
-## Performance
+## Internals
 
-### Asymptotics
+IdList stores its state as a modified [B+Tree](https://en.wikipedia.org/wiki/B%2B_tree), described at the top of [its source code](./src/id_list.ts). Each leaf in the B+Tree represents multiple ElementIds (sharing a bunchId and sequential counters) in a compressed way; for normal collaborative text editing, expect 10-20 ElementIds per leaf.
 
-IdList stores its state as a modified [B+Tree](https://en.wikipedia.org/wiki/B%252B_tree), described at the top of [its source code](./src/id_list.ts). Each leaf in the B+Tree represents multiple ids in a compressed way; for normal collaborative text editing, expect 10-20 ElementIds per leaf.
+In terms of the number of leaves `L`, mutating an IdList with insertAfter/insertBefore/delete/undelete will only create `O(log(L))` new tree nodes, reusing the rest. However, most methods currently take `O(L)` total time because they search the whole tree for a given ElementId, which has not yet been optimized (it uses a simple depth-first search). Exception: `IdList.at(index)` takes only `O(log(L))` time.
 
-In terms of the number of leaves `L`, mutating an IdList with insertAfter/insertBefore/delete/undelete will only create `O(log(L))` new tree nodes, reusing the rest. However, most methods currently take `O(L)` total time because they search the whole tree for a given id, which has not yet been optimized (it uses a simple depth-first search). Exception: `IdList.at(index)` takes only `O(log(L))` time.
+If you want to get a sense of what IdList is or how to implement your own version, consider reading the source code for [IdListSimple](./test/id_list_simple.ts), which behaves identically to IdList. It is short (<300 SLOC) and direct, using an array and splicing operations. The downside is that IdListSimple does not compress ElementIds, and all of its operations take `O(# ids)` time. We use it as a known-good implementation in our fuzz tests.
+
+<!-- TODO: related work: CRDTs, ropes, list-positions, ?? -->

--- a/README.md
+++ b/README.md
@@ -111,6 +111,6 @@ IdList stores its state as a modified [B+Tree](https://en.wikipedia.org/wiki/B%2
 
 In terms of the number of leaves `L`, mutating an IdList with insertAfter/insertBefore/delete/undelete will only create `O(log(L))` new tree nodes, reusing the rest. However, most methods currently take `O(L)` total time because they search the whole tree for a given ElementId, which has not yet been optimized (it uses a simple depth-first search). Exception: `IdList.at(index)` takes only `O(log(L))` time.
 
-If you want to get a sense of what IdList is or how to implement your own version, consider reading the source code for [IdListSimple](./test/id_list_simple.ts), which behaves identically to IdList. It is short (<300 SLOC) and direct, using an array and splicing operations. The downside is that IdListSimple does not compress ElementIds, and all of its operations take `O(# ids)` time. We use it as a known-good implementation in our fuzz tests.
+If you want to get a sense of what IdList is or how to implement your own version, consider reading the source code for [IdListSimple](./test/id_list_simple.ts), which behaves identically to IdList. It is short (<300 SLOC) and direct, using an array and `Array.splice`. The downside is that IdListSimple does not compress ElementIds, and all of its operations take `O(# ids)` time. We use it as a known-good implementation in our fuzz tests.
 
 <!-- TODO: related work: CRDTs, ropes, list-positions, ?? -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.4",
         "@types/mocha": "^10.0.1",
+        "@types/seedrandom": "^3.0.8",
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",
         "chai": "^4.3.7",
@@ -25,6 +26,7 @@
         "npm-run-all": "^4.1.5",
         "nyc": "^15.1.0",
         "prettier": "^2.8.4",
+        "seedrandom": "^3.0.5",
         "ts-node": "^10.9.2",
         "typedoc": "^0.25.13",
         "typescript": "^5.4.5"
@@ -913,6 +915,12 @@
       "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/seedrandom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.8.tgz",
+      "integrity": "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -4916,6 +4924,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -6517,6 +6531,12 @@
       "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true,
       "peer": true
+    },
+    "@types/seedrandom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.8.tgz",
+      "integrity": "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.5.8",
@@ -9373,6 +9393,12 @@
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
       }
+    },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
     },
     "semver": {
       "version": "7.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "articulated",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "sparse-array-rled": "^2.0.1"
+      },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.4",
@@ -5059,6 +5062,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sparse-array-rled": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sparse-array-rled/-/sparse-array-rled-2.0.1.tgz",
+      "integrity": "sha512-kfJ0KmfahwO4s+dClWfT3HoWou2fNJy+1xOPY9kNr91lum9FYq5Pza7Y1qDx/gmdSsQ3tl5CnFlIP4jnO6xgZQ=="
+    },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -9478,6 +9486,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "sparse-array-rled": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sparse-array-rled/-/sparse-array-rled-2.0.1.tgz",
+      "integrity": "sha512-kfJ0KmfahwO4s+dClWfT3HoWou2fNJy+1xOPY9kNr91lum9FYq5Pza7Y1qDx/gmdSsQ3tl5CnFlIP4jnO6xgZQ=="
     },
     "spawn-wrap": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
+    "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "chai": "^4.3.7",
@@ -46,6 +47,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.8.4",
+    "seedrandom": "^3.0.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
     "typescript": "^5.4.5"

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "fix:format": "prettier --write .",
     "docs": "typedoc --options typedoc.json src/index.ts",
     "clean": "rm -rf build docs coverage .nyc_output"
+  },
+  "dependencies": {
+    "sparse-array-rled": "^2.0.1"
   }
 }

--- a/src/id.ts
+++ b/src/id.ts
@@ -3,12 +3,12 @@
  *
  * ElementIds are conceptually the same as UUIDs (or nanoids, etc.).
  * However, when a single thread generates a series of ElementIds, you are
- * allowed to optimize by generating a single UUID/nanoid/etc. and using that as the "bunchId"
+ * allowed to optimize by generating a single UUID/nanoid/etc. and using that as the `bunchId`
  * for a "bunch" of elements, with varying `counter`.
  * The resulting ElementIds compress better than a set of UUIDs, but they are
- * still globally unique, even if another thread/user/device generates ElementIds concurrently.
+ * still globally unique, even if another thread/device/user generates ElementIds concurrently.
  *
- * For example, if a user types a sentence from left to right, you may generate a
+ * For example, if a user types a sentence from left to right, you can generate a
  * single `bunchId` and assign their characters the sequential ElementIds
  * `{ bunchId, counter: 0 }, { bunchId, counter: 1 }, { bunchId, counter: 2 }, ...`.
  * An IdList will store all of these as a single object instead of

--- a/src/id.ts
+++ b/src/id.ts
@@ -34,9 +34,6 @@ export interface ElementId {
    */
   readonly counter: number;
 }
-// TODO: Allow negative counters? Don't work with SparseIndices.
-// "Negative integers are supported by IdList (e.g., for optimized right-to-left insertions),
-// though you may choose to avoid these in your application, to make serialization easier."
 
 /**
  * Equals function for ElementIds.

--- a/src/id.ts
+++ b/src/id.ts
@@ -31,12 +31,12 @@ export interface ElementId {
    * IdList is optimized for this case, but it is not mandatory.
    * In particular, it is okay if future edits cause the sequential ids to be
    * separated, partially deleted, or even reordered.
-   *
-   * Negative integers are supported by IdList (e.g., for optimized right-to-left insertions),
-   * though you may choose to avoid these in your application, to make serialization easier.
    */
   readonly counter: number;
 }
+// TODO: Allow negative counters? Don't work with SparseIndices.
+// "Negative integers are supported by IdList (e.g., for optimized right-to-left insertions),
+// though you may choose to avoid these in your application, to make serialization easier."
 
 /**
  * Equals function for ElementIds.

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -14,18 +14,18 @@ import { SavedIdList } from "./saved_id_list";
  The B+Tree is unusual in that it has no keys, only values (= ids). The order on the values
  is determined "by fiat" using insertAfter/insertBefore instead of using sorted keys.
 
- The leaves in the B+Tree are not individual ids; instead, each leaf is a compressed reprsentation of a groups of ids
+ The leaves in the B+Tree are not individual ids; instead, each leaf is a compressed representation of a groups of ids
  with the same bunchId and sequential counters. Each leaf also contains a `present`
- field to track which of its ids are not deleted.
+ field to track which of its ids are deleted.
  (Unlike in a SavedIdList, we do not separate adjacent ids with different isDeleted statuses.)
 
  Note that it is possible for adjacent leaves to be mergeable (i.e., they could be one leaf) but not merged.
  This happens if you insert the middle ids later (e.g., 0, 2, 1).
  It has a slight perf penalty that goes away once you reload.
- Note that save() needs to work around this possibility (see pushSaveItem).
+ Note that save() needs to work around this possibility - see pushSaveItem.
 
- The B+Tree also stores two statistics about each subtree: its size (# of present ids),
- and its knownSize (# of known ids). These are used to allow indexed access in log time.
+ The B+Tree also stores two statistics about each subtree: its size (# of present ids)
+ and its knownSize (# of known ids). These allow indexed access in log time.
 
  Unlike some B+Trees, we do not store a linked list of leaves. Iteration instead uses a depth-first search.
 */
@@ -37,11 +37,14 @@ export interface LeafNode {
   /**
    * The present counter values in this leaf node.
    *
-   * Note that it starts at this.count, not 0.
+   * Note that it is indexed by counter, not by (counter - this.startCounter).
    */
   readonly present: SparseIndices;
 }
 
+/**
+ * An inner node with inner-node children.
+ */
 export class InnerNodeInner {
   readonly size: number;
   readonly knownSize: number;
@@ -58,6 +61,9 @@ export class InnerNodeInner {
   }
 }
 
+/**
+ * An inner node with leaf children.
+ */
 export class InnerNodeLeaf {
   readonly size: number;
   readonly knownSize: number;
@@ -76,12 +82,6 @@ export class InnerNodeLeaf {
 
 export type InnerNode = InnerNodeInner | InnerNodeLeaf;
 
-type Located = [
-  { node: LeafNode; indexInParent: number },
-  // Index 1 will be an InnerNodeLeaf if it exists.
-  ...{ node: InnerNode; indexInParent: number }[]
-];
-
 /**
  * The B+Tree's branching factor, i.e., the max number of children of a node.
  *
@@ -89,7 +89,7 @@ type Located = [
  *
  * Wiki B+Tree: "B+ trees can also be used for data stored in RAM.
  * In this case a reasonable choice for block size would be the size of [the] processor's cache line."
- * (64 bytes) / (8 byte pointer) = 8.
+ * (64 byte cache line) / (8 byte pointer) = 8.
  */
 export const M = 8;
 
@@ -126,7 +126,8 @@ export class IdList {
   /**
    * Constructs an empty list.
    *
-   * To begin with a non-empty list, use {@link IdList.from} or {@link IdList.fromIds}.
+   * To begin with a non-empty list, use {@link IdList.from}, {@link IdList.fromIds},
+   * or {@link IdList.load}.
    */
   static new() {
     return new this(new InnerNodeLeaf([]));
@@ -143,12 +144,13 @@ export class IdList {
 
     for (const { id, isDeleted } of knownIds) {
       if (savedState.length !== 0) {
-        const current = savedState[savedState.length - 1];
+        const current = savedState.at(-1)!;
         if (
           id.bunchId === current.bunchId &&
           id.counter === current.startCounter + current.count &&
           isDeleted === current.isDeleted
         ) {
+          // @ts-expect-error Mutating for convenience; no aliasing to worry about.
           current.count++;
           continue;
         }
@@ -321,24 +323,12 @@ export class IdList {
     if (after === null) {
       if (count === 0) return this;
 
-      if (this.root.children.length === 0) {
-        // Insert the first leaf as a child of root.
-        const present = SparseIndices.new();
-        present.set(newId.counter, count);
-        return new IdList(
-          new InnerNodeLeaf([
-            {
-              bunchId: newId.bunchId,
-              startCounter: newId.counter,
-              count,
-              present,
-            },
-          ])
-        );
-      } else {
-        // Insert after the first known id.
-        return this.insertAfter(lastId(this.root), newId, count);
-      }
+      // Insert after the last known id, or at the beginning if empty.
+      return this.insertAfter(
+        this.root.knownSize === 0 ? null : lastId(this.root),
+        newId,
+        count
+      );
     }
 
     const located = locate(after, this.root);
@@ -460,7 +450,7 @@ export class IdList {
 
   /**
    * Replaces the leaf at the given path with newLeaves.
-   * Returns a proper BTree with updated sizes.
+   * Returns a proper (sufficiently balanced) B+Tree with updated sizes.
    *
    * newLeaves.length must be in [1, M].
    */
@@ -584,8 +574,7 @@ export class IdList {
     }
 
     // id's index within leaf.
-    const idLeaf = leafParent.children[located[0].indexInParent];
-    const [count, has] = idLeaf.present._countHas(id.counter);
+    const [count, has] = located[0].node.present._countHas(id.counter);
     index += count;
     if (has) return index;
     else {
@@ -619,8 +608,11 @@ export class IdList {
   /**
    * Iterates over all __known__ ids in the list, indicating which are deleted.
    */
-  valuesWithDeleted(): IterableIterator<{ id: ElementId; isDeleted: boolean }> {
-    return iterateNodeWithDeleted(this.root);
+  valuesWithIsDeleted(): IterableIterator<{
+    id: ElementId;
+    isDeleted: boolean;
+  }> {
+    return iterateNodeWithIsDeleted(this.root);
   }
 
   private _knownIds?: KnownIdView;
@@ -681,8 +673,9 @@ export class IdList {
           // Okay to mutate in-place since we haven't referenced it anywhere else yet.
           // @ts-expect-error Mutate in place
           lastLeaf.count += item.count;
-          if (!item.isDeleted)
+          if (!item.isDeleted) {
             lastLeaf.present.set(item.startCounter, item.count);
+          }
           continue;
         }
       }
@@ -703,30 +696,14 @@ export class IdList {
     // leaves one-by-one, which would take O(n log(n)) time.
 
     if (leaves.length === 0) return IdList.new();
-    // Depth of the B+Tree, excluding the root.
-    // A B+Tree of depth d has between [M^{d-1} - 1, M^d] leaves.
-    let depth = Math.ceil(Math.log(leaves.length) / Math.log(M));
-    if (depth === 0) depth = 1;
-    return new IdList(buildTree(leaves, 0, depth - 1));
-  }
-}
 
-function buildTree(
-  leaves: LeafNode[],
-  startIndex: number,
-  depthRemaining: number
-): InnerNode {
-  if (depthRemaining === 0) {
-    return new InnerNodeLeaf(leaves.slice(startIndex, startIndex + M));
-  } else {
-    const children: InnerNode[] = [];
-    const childLeafCount = Math.pow(M, depthRemaining);
-    for (let i = 0; i < M; i++) {
-      const childStartIndex = startIndex + i * childLeafCount;
-      if (childStartIndex >= leaves.length) break;
-      children.push(buildTree(leaves, childStartIndex, depthRemaining - 1));
-    }
-    return new InnerNodeInner(children);
+    // Depth of the B+Tree (number of non-root nodes on any path from a leaf to the root).
+    // A fully balanced B+Tree of depth d has between [M^{d-1} + 1, M^d] leaves.
+    const depth =
+      leaves.length === 1
+        ? 1
+        : Math.ceil(Math.log(leaves.length) / Math.log(M));
+    return new IdList(buildTree(leaves, 0, depth));
   }
 }
 
@@ -825,8 +802,7 @@ export class KnownIdView {
     }
 
     // id's index with leaf.
-    const idLeaf = leafParent.children[located[0].indexInParent];
-    return index + (id.counter - idLeaf.startCounter);
+    return index + (id.counter - located[0].node.startCounter);
   }
 
   /**
@@ -855,6 +831,9 @@ export class KnownIdView {
   }
 }
 
+/**
+ * Returns the first (leftmost) known ElementId in node's subtree.
+ */
 function firstId(node: InnerNode): ElementId {
   let currentInner = node;
   while (!(currentInner instanceof InnerNodeLeaf)) {
@@ -867,6 +846,9 @@ function firstId(node: InnerNode): ElementId {
   };
 }
 
+/**
+ * Returns the last (rightmost) known ElementId in node's subtree.
+ */
 function lastId(node: InnerNode): ElementId {
   let currentInner = node;
   while (!(currentInner instanceof InnerNodeLeaf)) {
@@ -875,9 +857,15 @@ function lastId(node: InnerNode): ElementId {
   const lastLeaf = currentInner.children.at(-1)!;
   return {
     bunchId: lastLeaf.bunchId,
-    counter: lastLeaf.startCounter,
+    counter: lastLeaf.startCounter + lastLeaf.count - 1,
   };
 }
+
+type Located = [
+  { node: LeafNode; indexInParent: number },
+  // Index 1 will be an InnerNodeLeaf if it exists.
+  ...{ node: InnerNode; indexInParent: number }[]
+];
 
 /**
  * Returns the path from id's leaf node to the root, or null if id is not found.
@@ -937,7 +925,7 @@ function isAnyKnown(id: ElementId, count: number, node: InnerNode): boolean {
 }
 
 /**
- * Replace located[i].node with newNodes. root is effectively located[located.length].node.
+ * Replace located[i].node with newNodes.
  *
  * newNodes.length must be in [1, M].
  */
@@ -956,7 +944,8 @@ function replaceNode(
     .concat(newNodes, parent.children.slice(indexInParent + 1));
 
   if (newChildren.length > M) {
-    const split = Math.floor(newChildren.length / 2);
+    // Split the parent to maintain BTree property (# children <= M).
+    const split = Math.ceil(newChildren.length / 2);
     const newParents = [
       newChildren.slice(0, split),
       newChildren.slice(split),
@@ -985,6 +974,9 @@ function replaceNode(
   }
 }
 
+/**
+ * Splits present into two SparseIndices at the given counter.
+ */
 function splitPresent(
   present: SparseIndices,
   splitCounter: number
@@ -1024,12 +1016,12 @@ function* iterateNode(
   }
 }
 
-function* iterateNodeWithDeleted(
+function* iterateNodeWithIsDeleted(
   node: InnerNode
 ): IterableIterator<{ id: ElementId; isDeleted: boolean }> {
   if (node instanceof InnerNodeInner) {
     for (const child of node.children) {
-      yield* iterateNodeWithDeleted(child);
+      yield* iterateNodeWithIsDeleted(child);
     }
   } else {
     for (const child of node.children) {
@@ -1059,6 +1051,10 @@ function* iterateNodeWithDeleted(
   }
 }
 
+/**
+ * Updates acc to account for node's subtree, as part of a depth-first search
+ * in list order.
+ */
 function saveNode(node: InnerNode, acc: SavedIdList) {
   if (node instanceof InnerNodeInner) {
     for (const child of node.children) {
@@ -1098,7 +1094,7 @@ function saveNode(node: InnerNode, acc: SavedIdList) {
 }
 
 /**
- * Pushes a save item onto acc, combing it with the previous item if possible
+ * Pushes a save item onto acc, combing it with the previous item if possible.
  *
  * This function is necessary because we don't guarantee that adjacent leaves are fully merged.
  * Specifically, if you insert a bunch's ids with counter values (0, 2, 1)
@@ -1118,9 +1114,36 @@ function pushSaveItem(acc: SavedIdList, item: SavedIdList[number]) {
       previous.startCounter + previous.count === item.startCounter
     ) {
       // Combine items.
+      // @ts-expect-error Mutating for convenience; no aliasing to worry about.
       previous.count += item.count;
       return;
     }
   }
   acc.push(item);
+}
+
+/**
+ * Builds a tree with the given leaves. Used by IdList.load.
+ *
+ * In contrast to inserting the leaves one-by-one, this function balances the
+ * tree, with full inner nodes (M children) whenever possible,
+ * and runs in O(L) time instead of O(L log(L)).
+ */
+function buildTree(
+  leaves: LeafNode[],
+  startIndex: number,
+  depthRemaining: number
+): InnerNode {
+  if (depthRemaining === 1) {
+    return new InnerNodeLeaf(leaves.slice(startIndex, startIndex + M));
+  } else {
+    const children: InnerNode[] = [];
+    const childLeafCount = Math.pow(M, depthRemaining - 1);
+    for (let i = 0; i < M; i++) {
+      const childStartIndex = startIndex + i * childLeafCount;
+      if (childStartIndex >= leaves.length) break;
+      children.push(buildTree(leaves, childStartIndex, depthRemaining - 1));
+    }
+    return new InnerNodeInner(children);
+  }
 }

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -180,6 +180,8 @@ export class IdList {
     if (!(Number.isSafeInteger(count) && count >= 0)) {
       throw new Error(`Invalid count: ${count}`);
     }
+    // TODO: This doesn't check if newId...count ids are known.
+    // Likewise in insertBefore and IdListSimple.
     if (this.isKnown(newId)) {
       throw new Error("newId is already known");
     }
@@ -1007,7 +1009,11 @@ function* iterateNodeWithDeleted(
   }
 }
 
-// TODO: Test that entries are fully merged with their neighbors. Also, no 0s.
+// TODO: It's possible for adjacent leaves to be mergeable but not merged.
+// This happens if you insert a bunch in pattern 0, 2, 1.
+// I think that's okay (just a perf issue that goes away after reloading),
+// but we need to merge the resulting save items, document it,
+// and check that no other parts of the code depend on fully-merged leaves.
 function saveNode(node: InnerNode, acc: SavedIdList) {
   if (node instanceof InnerNodeInner) {
     for (const child of node.children) {

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -2,7 +2,9 @@ import { SparseIndices } from "sparse-array-rled";
 import { ElementId } from "./id";
 import { SavedIdList } from "./saved_id_list";
 
-interface LeafNode {
+// Most exports are only for tests. See index.ts for public exports.
+
+export interface LeafNode {
   readonly bunchId: string;
   readonly startCounter: number;
   readonly count: number;
@@ -14,7 +16,7 @@ interface LeafNode {
   readonly present: SparseIndices;
 }
 
-class InnerNodeInner {
+export class InnerNodeInner {
   readonly size: number;
   readonly knownSize: number;
 
@@ -30,7 +32,7 @@ class InnerNodeInner {
   }
 }
 
-class InnerNodeLeaf {
+export class InnerNodeLeaf {
   readonly size: number;
   readonly knownSize: number;
 
@@ -46,7 +48,7 @@ class InnerNodeLeaf {
   }
 }
 
-type InnerNode = InnerNodeInner | InnerNodeLeaf;
+export type InnerNode = InnerNodeInner | InnerNodeLeaf;
 
 type Located = [
   { node: LeafNode; indexInParent: number },
@@ -63,7 +65,7 @@ type Located = [
  * In this case a reasonable choice for block size would be the size of [the] processor's cache line."
  * (64 bytes) / (8 byte pointer) = 8.
  */
-const M = 8;
+export const M = 8;
 
 // TODO:
 // - Move helper methods to functions, for minification.
@@ -857,7 +859,7 @@ function lastId(node: InnerNode): ElementId {
  * The path contains each node and its index in its parent's node, starting with id's
  * LeafNode and ending at a child of the root.
  */
-function locate(id: ElementId, node: InnerNode): Located | null {
+export function locate(id: ElementId, node: InnerNode): Located | null {
   if (node instanceof InnerNodeInner) {
     for (let i = 0; i < node.children.length; i++) {
       const child = node.children[i];

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -172,6 +172,9 @@ export class IdList {
    * @throws If `newId` is already known.
    */
   insertAfter(before: ElementId | null, newId: ElementId, count = 1): IdList {
+    if (!(Number.isSafeInteger(newId.counter) && newId.counter >= 0)) {
+      throw new Error(`Invalid counter: ${newId.counter}`);
+    }
     if (!(Number.isSafeInteger(count) && count >= 0)) {
       throw new Error(`Invalid count: ${count}`);
     }
@@ -281,6 +284,9 @@ export class IdList {
    * @throws If `newId` is already known.
    */
   insertBefore(after: ElementId | null, newId: ElementId, count = 1): IdList {
+    if (!(Number.isSafeInteger(newId.counter) && newId.counter >= 0)) {
+      throw new Error(`Invalid counter: ${newId.counter}`);
+    }
     if (!(Number.isSafeInteger(count) && count >= 0)) {
       throw new Error(`Invalid count: ${count}`);
     }
@@ -386,9 +392,6 @@ export class IdList {
    * Because `id` is still known, you can reference it in future insertAfter/insertBefore
    * operations, including ones sent concurrently by other devices.
    * However, it does occupy space in memory (compressed in common cases).
-   *
-   * For an exact inverse to `insertAfter(-, id)` or `insertBefore(-, id)`
-   * that makes `id` no longer known, see {@link uninsert}.
    *
    * If `id` is already deleted or not known, this method does nothing.
    */
@@ -1028,6 +1031,14 @@ function saveNode(node: InnerNode, acc: SavedIdList) {
           isDeleted: false,
         });
         nextIndex = index + count;
+      }
+      if (nextIndex < child.startCounter + child.count) {
+        acc.push({
+          bunchId: child.bunchId,
+          startCounter: nextIndex,
+          count: child.startCounter + child.count - nextIndex,
+          isDeleted: true,
+        });
       }
     }
   }

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -987,7 +987,7 @@ function* iterateWithDeletedNode(
   }
 }
 
-// TODO: Test that entries are fully merged with their neighbors.
+// TODO: Test that entries are fully merged with their neighbors. Also, no 0s.
 function saveNode(node: InnerNode, acc: SavedIdList) {
   if (node instanceof InnerNodeInner) {
     for (const child of node.children) {
@@ -995,12 +995,25 @@ function saveNode(node: InnerNode, acc: SavedIdList) {
     }
   } else {
     for (const child of node.children) {
-      acc.push({
-        bunchId: child.bunchId,
-        startCounter: child.startCounter,
-        count: child.count,
-        isDeleted: child.isDeleted,
-      });
+      let nextIndex = child.startCounter;
+      for (const [index, count] of child.present.items()) {
+        if (nextIndex < index) {
+          // Need a deleted item.
+          acc.push({
+            bunchId: child.bunchId,
+            startCounter: nextIndex,
+            count: index - nextIndex,
+            isDeleted: true,
+          });
+        }
+        acc.push({
+          bunchId: child.bunchId,
+          startCounter: index,
+          count,
+          isDeleted: false,
+        });
+        nextIndex = index + count;
+      }
     }
   }
 }

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -93,9 +93,6 @@ type Located = [
  */
 export const M = 8;
 
-// TODO: Combine at/indexOf with KnownId versions, for easier modification & smaller code.
-// TODO: Future release: faster searching (not O(# leaves)).
-
 /**
  * A list of ElementIds, as a persistent (immutable) data structure.
  *
@@ -651,8 +648,6 @@ export class IdList {
    * Loads a saved state returned by {@link save}.
    */
   static load(savedState: SavedIdList) {
-    // TODO: Checks to ban duplicate ids.
-
     // 1. Determine the leaves.
 
     const leaves: LeafNode[] = [];

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -68,8 +68,9 @@ type Located = [
 export const M = 8;
 
 // TODO:
-// - Move helper methods to functions, for minification.
 // - Combine at/indexOf with KnownId versions, for easier modification & smaller code.
+// - Describe B+Tree here. Describe asymptotics in readme.
+// - Future release: faster searching (not O(# leaves)).
 
 /**
  * A list of ElementIds, as a persistent (immutable) data structure.

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -67,10 +67,9 @@ type Located = [
  */
 export const M = 8;
 
-// TODO:
-// - Combine at/indexOf with KnownId versions, for easier modification & smaller code.
-// - Describe B+Tree here. Describe asymptotics in readme.
-// - Future release: faster searching (not O(# leaves)).
+// TODO: Combine at/indexOf with KnownId versions, for easier modification & smaller code.
+// TODO: Describe B+Tree here. Describe asymptotics in readme.
+// TODO: Future release: faster searching (not O(# leaves)).
 
 /**
  * A list of ElementIds, as a persistent (immutable) data structure.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./id";
-export * from "./id_list";
+export { IdList, KnownIdView } from "./id_list";
 export * from "./saved_id_list";

--- a/src/saved_id_list.ts
+++ b/src/saved_id_list.ts
@@ -1,5 +1,5 @@
 /**
- * Saved state for an IdList.
+ * JSON saved state for an IdList.
  *
  * It describes all of the list's known ElementIds in list order, with basic compression:
  * if sequential ElementIds have the same bunchId, the same isDeleted status,

--- a/src/saved_id_list.ts
+++ b/src/saved_id_list.ts
@@ -6,8 +6,8 @@
  * and sequential counters, then they are combined into a single object.
  */
 export type SavedIdList = Array<{
-  bunchId: string;
-  startCounter: number;
-  count: number;
-  isDeleted: boolean;
+  readonly bunchId: string;
+  readonly startCounter: number;
+  readonly count: number;
+  readonly isDeleted: boolean;
 }>;

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -511,7 +511,22 @@ describe("IdList", () => {
       ];
       expect([...IdList.load(savedState4)]).to.deep.equal([]);
 
-      // Negative counters are okay.
+      // // Negative counters are okay.
+      // const savedState5: SavedIdList = [
+      //   {
+      //     bunchId: "abc",
+      //     startCounter: -1,
+      //     count: 3,
+      //     isDeleted: false,
+      //   },
+      // ];
+      // expect([...IdList.load(savedState5)]).to.deep.equal([
+      //   { bunchId: "abc", counter: -1 },
+      //   { bunchId: "abc", counter: 0 },
+      //   { bunchId: "abc", counter: 1 },
+      // ]);
+
+      // Negative counters are not allowed.
       const savedState5: SavedIdList = [
         {
           bunchId: "abc",
@@ -520,11 +535,7 @@ describe("IdList", () => {
           isDeleted: false,
         },
       ];
-      expect([...IdList.load(savedState5)]).to.deep.equal([
-        { bunchId: "abc", counter: -1 },
-        { bunchId: "abc", counter: 0 },
-        { bunchId: "abc", counter: 1 },
-      ]);
+      expect(() => IdList.load(savedState5)).to.throw();
     });
   });
 });

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -276,8 +276,6 @@ describe("IdList", () => {
     });
   });
 
-  // TODO: Test immutability.
-
   describe("accessor operations", () => {
     let list: IdList;
     const id1: ElementId = { bunchId: "abc", counter: 1 };

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -144,6 +144,25 @@ describe("IdList", () => {
       expect(equalsId(list.at(1), id1)).to.be.true;
     });
 
+    it("should insert before the end", () => {
+      let list = IdList.new();
+      const id1: ElementId = { bunchId: "abc", counter: 1 };
+      const id2: ElementId = { bunchId: "def", counter: 1 };
+
+      // Insert before null when the list is empty.
+      list = list.insertBefore(null, id1, 3);
+
+      expect(list.length).to.equal(3);
+      expect(equalsId(list.at(0), id1)).to.be.true;
+
+      // Insert before null when the list has ids.
+      list = list.insertBefore(null, id2);
+
+      expect(list.length).to.equal(4);
+      expect(equalsId(list.at(3), id2)).to.be.true;
+      expect(equalsId(list.at(0), id1)).to.be.true;
+    });
+
     it("should bulk insert multiple elements", () => {
       let list = IdList.new();
       const startId: ElementId = { bunchId: "abc", counter: 1 };
@@ -344,8 +363,8 @@ describe("IdList", () => {
       expect(equalsId(ids[1], id3)).to.be.true;
     });
 
-    it("should iterate over all known elements with valuesWithDeleted", () => {
-      const elements = [...list.valuesWithDeleted()];
+    it("should iterate over all known elements with valuesWithIsDeleted", () => {
+      const elements = [...list.valuesWithIsDeleted()];
       expect(elements).to.have.length(3);
 
       expect(equalsId(elements[0].id, id1)).to.be.true;

--- a/test/basic_fuzz.test.ts
+++ b/test/basic_fuzz.test.ts
@@ -1,0 +1,649 @@
+import seedrandom from "seedrandom";
+import { ElementId } from "../src";
+import { Fuzzer } from "./fuzzer";
+
+describe("IdList Fuzzer Tests", () => {
+  let prng!: seedrandom.PRNG;
+
+  beforeEach(() => {
+    prng = seedrandom("42");
+  });
+
+  // Helper to create random ElementIds
+  const createRandomId = (): ElementId => {
+    const bunchId = `bunch-${Math.floor(prng() * 10)}`;
+    const counter = Math.floor(prng() * 100);
+    return { bunchId, counter };
+  };
+
+  // Helper to create sequential ElementIds
+  const createSequentialIds = (
+    count: number,
+    bunchId = "sequential",
+    startCounter = 0
+  ): ElementId[] => {
+    const ids: ElementId[] = [];
+    for (let i = 0; i < count; i++) {
+      ids.push({ bunchId, counter: startCounter + i });
+    }
+    return ids;
+  };
+
+  describe("Random Operation Sequences", () => {
+    it("should handle a random sequence of operations", () => {
+      let fuzzer = Fuzzer.new();
+      const knownIds: ElementId[] = [];
+
+      // Perform a sequence of random operations
+      const operationCount = 100;
+      for (let i = 0; i < operationCount; i++) {
+        // Every 10 operations, check all accessors
+        if (i % 10 === 0) {
+          fuzzer.checkAll();
+        }
+
+        const operation = Math.floor(prng() * 4); // 0-3 for different operations
+
+        switch (operation) {
+          case 0: // insertAfter
+            {
+              const newId = createRandomId();
+              const beforeIndex =
+                knownIds.length > 0 ? Math.floor(prng() * knownIds.length) : -1;
+              const before = beforeIndex >= 0 ? knownIds[beforeIndex] : null;
+              const count = Math.floor(prng() * 3) + 1; // 1-3 elements
+
+              try {
+                fuzzer = fuzzer.insertAfter(before, newId, count);
+                // Add the new IDs to our known list
+                for (let j = 0; j < count; j++) {
+                  knownIds.push({
+                    bunchId: newId.bunchId,
+                    counter: newId.counter + j,
+                  });
+                }
+              } catch (e) {
+                // This might fail legitimately if the ID already exists
+                // Just continue with the next operation
+              }
+            }
+            break;
+
+          case 1: // insertBefore
+            {
+              const newId = createRandomId();
+              const afterIndex =
+                knownIds.length > 0 ? Math.floor(prng() * knownIds.length) : -1;
+              const after = afterIndex >= 0 ? knownIds[afterIndex] : null;
+              const count = Math.floor(prng() * 3) + 1; // 1-3 elements
+
+              try {
+                fuzzer = fuzzer.insertBefore(after, newId, count);
+                // Add the new IDs to our known list
+                for (let j = 0; j < count; j++) {
+                  knownIds.push({
+                    bunchId: newId.bunchId,
+                    counter: newId.counter + j,
+                  });
+                }
+              } catch (e) {
+                // This might fail legitimately if the ID already exists
+                // Just continue with the next operation
+              }
+            }
+            break;
+
+          case 2: // delete
+            if (knownIds.length > 0) {
+              const index = Math.floor(prng() * knownIds.length);
+              const id = knownIds[index];
+              fuzzer = fuzzer.delete(id);
+              // We keep the ID in knownIds since it's still known, just deleted
+            }
+            break;
+
+          case 3: // undelete
+            if (knownIds.length > 0) {
+              const index = Math.floor(prng() * knownIds.length);
+              const id = knownIds[index];
+              try {
+                fuzzer = fuzzer.undelete(id);
+              } catch (e) {
+                // This might fail if the ID wasn't deleted
+                // Just continue with the next operation
+              }
+            }
+            break;
+        }
+      }
+
+      // Final check of all accessors
+      fuzzer.checkAll();
+    });
+
+    it("should handle multiple random sequences with different seeds", function () {
+      this.timeout(5000); // Increase timeout for this test
+
+      const seeds = ["42", "1337", "2468", "9876"];
+      const operationCount = 50; // Reduced to keep test time reasonable
+
+      for (const seed of seeds) {
+        prng = seedrandom(seed);
+        let fuzzer = Fuzzer.new();
+        const knownIds: ElementId[] = [];
+
+        for (let i = 0; i < operationCount; i++) {
+          const operation = Math.floor(prng() * 4);
+
+          if (i % 10 === 0) {
+            fuzzer.checkAll();
+          }
+
+          try {
+            switch (operation) {
+              case 0: // insertAfter
+                {
+                  const newId = createRandomId();
+                  const beforeIndex =
+                    knownIds.length > 0
+                      ? Math.floor(prng() * knownIds.length)
+                      : -1;
+                  const before =
+                    beforeIndex >= 0 ? knownIds[beforeIndex] : null;
+                  const count = Math.floor(prng() * 3) + 1;
+
+                  fuzzer = fuzzer.insertAfter(before, newId, count);
+                  for (let j = 0; j < count; j++) {
+                    knownIds.push({
+                      bunchId: newId.bunchId,
+                      counter: newId.counter + j,
+                    });
+                  }
+                }
+                break;
+
+              case 1: // insertBefore
+                {
+                  const newId = createRandomId();
+                  const afterIndex =
+                    knownIds.length > 0
+                      ? Math.floor(prng() * knownIds.length)
+                      : -1;
+                  const after = afterIndex >= 0 ? knownIds[afterIndex] : null;
+                  const count = Math.floor(prng() * 3) + 1;
+
+                  fuzzer = fuzzer.insertBefore(after, newId, count);
+                  for (let j = 0; j < count; j++) {
+                    knownIds.push({
+                      bunchId: newId.bunchId,
+                      counter: newId.counter + j,
+                    });
+                  }
+                }
+                break;
+
+              case 2: // delete
+                if (knownIds.length > 0) {
+                  const index = Math.floor(prng() * knownIds.length);
+                  fuzzer = fuzzer.delete(knownIds[index]);
+                }
+                break;
+
+              case 3: // undelete
+                if (knownIds.length > 0) {
+                  const index = Math.floor(prng() * knownIds.length);
+                  fuzzer = fuzzer.undelete(knownIds[index]);
+                }
+                break;
+            }
+          } catch (e) {
+            // Expected exceptions might occur, continue
+          }
+        }
+
+        fuzzer.checkAll();
+      }
+    });
+  });
+
+  describe("B+Tree Specific Fuzzing", () => {
+    it("should handle large sequential insertions to force tree growth", function () {
+      this.timeout(5000); // This test may take longer
+
+      let fuzzer = Fuzzer.new();
+      const batchSize = 10; // Number of elements to insert in each batch
+      const batchCount = 10; // Number of batches to insert
+
+      // This should create enough elements to force multiple tree levels
+      for (let batch = 0; batch < batchCount; batch++) {
+        // Check all accessors periodically
+        if (batch % 3 === 0) {
+          fuzzer.checkAll();
+        }
+
+        const batchId = createRandomId();
+        try {
+          fuzzer = fuzzer.insertAfter(null, batchId, batchSize);
+        } catch (e) {
+          // If this insertion fails, try with a different ID
+          const alternateBatchId = createRandomId();
+          fuzzer = fuzzer.insertAfter(null, alternateBatchId, batchSize);
+        }
+      }
+
+      fuzzer.checkAll();
+    });
+
+    it("should handle interleaved insertions that cause leaf splits", () => {
+      let fuzzer = Fuzzer.new();
+
+      // First create a sequential list of elements
+      const baseId = { bunchId: "base", counter: 0 };
+      fuzzer = fuzzer.insertAfter(null, baseId, 20);
+      fuzzer.checkAll();
+
+      // Now interleave new elements between existing ones to force leaf splits
+      for (let i = 0; i < 15; i += 2) {
+        const targetId = { bunchId: "base", counter: i };
+        const newId = { bunchId: `interleave-${i}`, counter: 0 };
+
+        fuzzer = fuzzer.insertAfter(targetId, newId);
+
+        // Check occasionally
+        if (i % 6 === 0) {
+          fuzzer.checkAll();
+        }
+      }
+
+      fuzzer.checkAll();
+    });
+
+    it("should handle operations near B+Tree node boundaries", function () {
+      this.timeout(5000);
+
+      let fuzzer = Fuzzer.new();
+      const M = 8; // The B+Tree branching factor used in IdList
+
+      // Create a list with exactly M elements
+      const ids = createSequentialIds(M);
+      fuzzer = Fuzzer.fromIds(ids);
+      fuzzer.checkAll();
+
+      // Insert at the boundary to force a split
+      fuzzer = fuzzer.insertAfter(ids[M - 1], {
+        bunchId: "boundary",
+        counter: 0,
+      });
+      fuzzer.checkAll();
+
+      // Insert at the middle of a leaf
+      fuzzer = fuzzer.insertAfter(ids[Math.floor(M / 2)], {
+        bunchId: "middle",
+        counter: 0,
+      });
+      fuzzer.checkAll();
+
+      // Delete elements at potential boundaries
+      fuzzer = fuzzer.delete(ids[M - 1]);
+      fuzzer = fuzzer.delete(ids[0]);
+      fuzzer.checkAll();
+
+      // Reinsert at those boundaries
+      fuzzer = fuzzer.insertBefore(ids[1], {
+        bunchId: "reinsertion",
+        counter: 0,
+      });
+      fuzzer = fuzzer.insertAfter(ids[M - 2], {
+        bunchId: "reinsertion",
+        counter: 1,
+      });
+      fuzzer.checkAll();
+    });
+
+    it("should handle bulk insertions at different tree positions", () => {
+      let fuzzer = Fuzzer.new();
+
+      // Create a base tree with some elements
+      const baseIds = createSequentialIds(15);
+      fuzzer = Fuzzer.fromIds(baseIds);
+      fuzzer.checkAll();
+
+      // Insert bulk elements at the beginning, middle, and end
+      fuzzer = fuzzer.insertBefore(
+        baseIds[0],
+        { bunchId: "start", counter: 0 },
+        5
+      );
+      fuzzer.checkAll();
+
+      fuzzer = fuzzer.insertAfter(
+        baseIds[7],
+        { bunchId: "middle", counter: 0 },
+        5
+      );
+      fuzzer.checkAll();
+
+      fuzzer = fuzzer.insertAfter(
+        baseIds[14],
+        { bunchId: "end", counter: 0 },
+        5
+      );
+      fuzzer.checkAll();
+
+      // Insert small batches at various positions
+      for (let i = 0; i < 10; i++) {
+        const targetIndex = Math.floor(prng() * baseIds.length);
+        const targetId = baseIds[targetIndex];
+        const newId = { bunchId: `batch-${i}`, counter: 0 };
+        const count = 1 + Math.floor(prng() * 3); // 1-3 elements
+
+        if (prng() > 0.5) {
+          fuzzer = fuzzer.insertAfter(targetId, newId, count);
+        } else {
+          fuzzer = fuzzer.insertBefore(targetId, newId, count);
+        }
+      }
+
+      fuzzer.checkAll();
+    });
+  });
+
+  describe("Edge Case Fuzzing", () => {
+    it("should handle operations on empty and near-empty lists", () => {
+      let fuzzer = Fuzzer.new();
+      fuzzer.checkAll();
+
+      // Insert and delete to empty
+      const id1 = createRandomId();
+      fuzzer = fuzzer.insertAfter(null, id1);
+      fuzzer.checkAll();
+
+      fuzzer = fuzzer.delete(id1);
+      fuzzer.checkAll();
+
+      // Insert, delete, then undelete
+      const id2 = createRandomId();
+      fuzzer = fuzzer.insertAfter(null, id2);
+      fuzzer = fuzzer.delete(id2);
+      fuzzer = fuzzer.undelete(id2);
+      fuzzer.checkAll();
+
+      // Insert after a deleted ID
+      const id3 = createRandomId();
+      fuzzer = fuzzer.insertAfter(id2, id3);
+      fuzzer.checkAll();
+
+      // Insert before a deleted ID
+      const id4 = createRandomId();
+      fuzzer = fuzzer.delete(id2);
+      fuzzer = fuzzer.insertBefore(id2, id4);
+      fuzzer.checkAll();
+    });
+
+    it("should handle extensive deletion and reinsertion", function () {
+      this.timeout(5000);
+
+      // Create a list with sequential elements
+      const ids = createSequentialIds(30);
+      let fuzzer = Fuzzer.fromIds(ids);
+      fuzzer.checkAll();
+
+      // Delete elements in a pattern
+      for (let i = 0; i < 30; i += 3) {
+        fuzzer = fuzzer.delete(ids[i]);
+
+        if (i % 9 === 0) {
+          fuzzer.checkAll();
+        }
+      }
+
+      fuzzer.checkAll();
+
+      // Reinsert elements at deleted positions
+      for (let i = 0; i < 30; i += 3) {
+        const newId = { bunchId: "reinsert", counter: i };
+
+        if (i % 2 === 0) {
+          fuzzer = fuzzer.insertAfter(ids[i], newId);
+        } else {
+          fuzzer = fuzzer.insertBefore(ids[i], newId);
+        }
+
+        if (i % 9 === 0) {
+          fuzzer.checkAll();
+        }
+      }
+
+      fuzzer.checkAll();
+
+      // Undelete some of the original deleted elements
+      for (let i = 0; i < 30; i += 6) {
+        fuzzer = fuzzer.undelete(ids[i]);
+      }
+
+      fuzzer.checkAll();
+    });
+
+    it("should handle sequential ID compression edge cases", () => {
+      let fuzzer = Fuzzer.new();
+
+      // Insert sequences with the same bunchId but gaps in counters
+      fuzzer = fuzzer.insertAfter(null, { bunchId: "sequence", counter: 0 }, 5);
+      fuzzer.checkAll();
+
+      // Insert a gap
+      fuzzer = fuzzer.insertAfter(
+        { bunchId: "sequence", counter: 4 },
+        { bunchId: "sequence", counter: 10 },
+        5
+      );
+      fuzzer.checkAll();
+
+      // Fill some of the gap
+      fuzzer = fuzzer.insertAfter(
+        { bunchId: "sequence", counter: 4 },
+        { bunchId: "sequence", counter: 5 },
+        2
+      );
+      fuzzer.checkAll();
+
+      // Delete alternating elements
+      for (let i = 0; i < 15; i += 2) {
+        if (i !== 6 && i !== 8) {
+          // Skip the gap
+          fuzzer = fuzzer.delete({ bunchId: "sequence", counter: i });
+        }
+      }
+      fuzzer.checkAll();
+
+      // Reinsert some elements with the same bunchId
+      fuzzer = fuzzer.insertAfter(
+        { bunchId: "sequence", counter: 3 },
+        { bunchId: "sequence", counter: 20 },
+        3
+      );
+      fuzzer.checkAll();
+    });
+
+    it("should handle a parameterized complex sequence of operations", function () {
+      this.timeout(10000); // Adjust timeout based on iterationCount
+
+      const iterationCount = 20; // Parameter to adjust test intensity
+      let fuzzer = Fuzzer.new();
+      const knownIds: ElementId[] = [];
+
+      for (let iteration = 0; iteration < iterationCount; iteration++) {
+        // Perform a mix of operations in each iteration
+
+        // Operation 1: Insert a batch of sequential IDs
+        const batchId = { bunchId: `batch-${iteration}`, counter: 0 };
+        const batchSize = 5 + Math.floor(prng() * 10); // 5-14 elements
+
+        try {
+          fuzzer = fuzzer.insertAfter(null, batchId, batchSize);
+          for (let i = 0; i < batchSize; i++) {
+            knownIds.push({ bunchId: batchId.bunchId, counter: i });
+          }
+        } catch (e) {
+          // Handle case where ID already exists
+        }
+
+        if (iteration % 5 === 0) {
+          fuzzer.checkAll();
+        }
+
+        // Operation 2: Delete some elements if we have enough
+        if (knownIds.length > 10) {
+          const deleteCount = 2 + Math.floor(prng() * 5); // 2-6 elements
+          for (let i = 0; i < deleteCount; i++) {
+            const idx = Math.floor(prng() * knownIds.length);
+            fuzzer = fuzzer.delete(knownIds[idx]);
+          }
+        }
+
+        // Operation 3: Interleave some insertions
+        if (knownIds.length > 0) {
+          const insertCount = 1 + Math.floor(prng() * 3); // 1-3 elements
+          for (let i = 0; i < insertCount; i++) {
+            const idx = Math.floor(prng() * knownIds.length);
+            const referenceId = knownIds[idx];
+            const newId = {
+              bunchId: `interleave-${iteration}-${i}`,
+              counter: 0,
+            };
+
+            try {
+              if (prng() > 0.5) {
+                fuzzer = fuzzer.insertAfter(referenceId, newId);
+              } else {
+                fuzzer = fuzzer.insertBefore(referenceId, newId);
+              }
+              knownIds.push(newId);
+            } catch (e) {
+              // Handle possible exceptions
+            }
+          }
+        }
+
+        // Operation 4: Undelete some elements
+        if (knownIds.length > 0) {
+          const undeleteCount = Math.floor(prng() * 3); // 0-2 elements
+          for (let i = 0; i < undeleteCount; i++) {
+            const idx = Math.floor(prng() * knownIds.length);
+            try {
+              fuzzer = fuzzer.undelete(knownIds[idx]);
+            } catch (e) {
+              // Handle case where element wasn't deleted
+            }
+          }
+        }
+
+        if (iteration % 5 === 0 || iteration === iterationCount - 1) {
+          fuzzer.checkAll();
+        }
+      }
+
+      // Final verification
+      fuzzer.checkAll();
+    });
+  });
+
+  describe("Save and Load Fuzzing", () => {
+    it("should maintain integrity through multiple save/load cycles", function () {
+      this.timeout(5000);
+
+      // Create an initial list with random operations
+      let fuzzer = Fuzzer.new();
+      const ids: ElementId[] = [];
+
+      // Perform some initial operations
+      for (let i = 0; i < 20; i++) {
+        const id = createRandomId();
+        try {
+          fuzzer = fuzzer.insertAfter(
+            ids.length > 0 ? ids[ids.length - 1] : null,
+            id
+          );
+          ids.push(id);
+        } catch (e) {
+          // Handle ID collision
+        }
+      }
+
+      // Delete some elements
+      for (let i = 0; i < 5; i++) {
+        const idx = Math.floor(prng() * ids.length);
+        fuzzer = fuzzer.delete(ids[idx]);
+      }
+
+      fuzzer.checkAll();
+
+      // Now perform save/load cycles with operations in between
+      for (let cycle = 0; cycle < 5; cycle++) {
+        // Get saved state from the current fuzzer
+        const savedState = fuzzer.list.save();
+
+        // Create a new fuzzer from the saved state
+        fuzzer = new Fuzzer(
+          IdList.load(savedState),
+          IdListSimple.load(savedState)
+        );
+
+        fuzzer.checkAll();
+
+        // Perform more operations
+        for (let i = 0; i < 5; i++) {
+          const operation = Math.floor(prng() * 4);
+
+          switch (operation) {
+            case 0: // insertAfter
+              {
+                const id = createRandomId();
+                const idx = Math.floor(prng() * ids.length);
+                try {
+                  fuzzer = fuzzer.insertAfter(ids[idx], id);
+                  ids.push(id);
+                } catch (e) {
+                  // Handle exceptions
+                }
+              }
+              break;
+
+            case 1: // insertBefore
+              {
+                const id = createRandomId();
+                const idx = Math.floor(prng() * ids.length);
+                try {
+                  fuzzer = fuzzer.insertBefore(ids[idx], id);
+                  ids.push(id);
+                } catch (e) {
+                  // Handle exceptions
+                }
+              }
+              break;
+
+            case 2: // delete
+              if (ids.length > 0) {
+                const idx = Math.floor(prng() * ids.length);
+                fuzzer = fuzzer.delete(ids[idx]);
+              }
+              break;
+
+            case 3: // undelete
+              if (ids.length > 0) {
+                const idx = Math.floor(prng() * ids.length);
+                try {
+                  fuzzer = fuzzer.undelete(ids[idx]);
+                } catch (e) {
+                  // Handle exceptions
+                }
+              }
+              break;
+          }
+        }
+
+        fuzzer.checkAll();
+      }
+    });
+  });
+});

--- a/test/basic_fuzz.test.ts
+++ b/test/basic_fuzz.test.ts
@@ -2,7 +2,7 @@ import { AssertionError } from "chai";
 import seedrandom from "seedrandom";
 import { ElementId, IdList } from "../src";
 import { Fuzzer } from "./fuzzer";
-import { IdList as IdListSimple } from "./id_list_simple";
+import { IdListSimple } from "./id_list_simple";
 
 describe("IdList Fuzzer Tests", () => {
   let prng!: seedrandom.PRNG;

--- a/test/basic_fuzz.test.ts
+++ b/test/basic_fuzz.test.ts
@@ -1,3 +1,4 @@
+import { AssertionError } from "chai";
 import seedrandom from "seedrandom";
 import { ElementId, IdList } from "../src";
 import { Fuzzer } from "./fuzzer";
@@ -64,6 +65,9 @@ describe("IdList Fuzzer Tests", () => {
                   });
                 }
               } catch (e) {
+                if (e instanceof AssertionError) {
+                  throw e;
+                }
                 // This might fail legitimately if the ID already exists
                 // Just continue with the next operation
               }
@@ -88,6 +92,9 @@ describe("IdList Fuzzer Tests", () => {
                   });
                 }
               } catch (e) {
+                if (e instanceof AssertionError) {
+                  throw e;
+                }
                 // This might fail legitimately if the ID already exists
                 // Just continue with the next operation
               }
@@ -110,6 +117,9 @@ describe("IdList Fuzzer Tests", () => {
               try {
                 fuzzer = fuzzer.undelete(id);
               } catch (e) {
+                if (e instanceof AssertionError) {
+                  throw e;
+                }
                 // This might fail if the ID wasn't deleted
                 // Just continue with the next operation
               }
@@ -198,7 +208,9 @@ describe("IdList Fuzzer Tests", () => {
                 break;
             }
           } catch (e) {
-            // TODO: remove?
+            if (e instanceof AssertionError) {
+              throw e;
+            }
             // Expected exceptions might occur, continue
           }
         }
@@ -227,6 +239,9 @@ describe("IdList Fuzzer Tests", () => {
         try {
           fuzzer = fuzzer.insertAfter(null, batchId, batchSize);
         } catch (e) {
+          if (e instanceof AssertionError) {
+            throw e;
+          }
           // If this insertion fails, try with a different ID
           const alternateBatchId = createRandomId();
           fuzzer = fuzzer.insertAfter(null, alternateBatchId, batchSize);
@@ -487,6 +502,9 @@ describe("IdList Fuzzer Tests", () => {
             knownIds.push({ bunchId: batchId.bunchId, counter: i });
           }
         } catch (e) {
+          if (e instanceof AssertionError) {
+            throw e;
+          }
           // Handle case where ID already exists
         }
 
@@ -522,6 +540,9 @@ describe("IdList Fuzzer Tests", () => {
               }
               knownIds.push(newId);
             } catch (e) {
+              if (e instanceof AssertionError) {
+                throw e;
+              }
               // Handle possible exceptions
             }
           }
@@ -535,6 +556,9 @@ describe("IdList Fuzzer Tests", () => {
             try {
               fuzzer = fuzzer.undelete(knownIds[idx]);
             } catch (e) {
+              if (e instanceof AssertionError) {
+                throw e;
+              }
               // Handle case where element wasn't deleted
             }
           }
@@ -568,6 +592,9 @@ describe("IdList Fuzzer Tests", () => {
           );
           ids.push(id);
         } catch (e) {
+          if (e instanceof AssertionError) {
+            throw e;
+          }
           // Handle ID collision
         }
       }
@@ -587,8 +614,8 @@ describe("IdList Fuzzer Tests", () => {
 
         // Create a new fuzzer from the saved state
         fuzzer = new Fuzzer(
-          IdList.load(savedState),
-          IdListSimple.load(savedState)
+          () => IdList.load(savedState),
+          () => IdListSimple.load(savedState)
         );
 
         fuzzer.checkAll();
@@ -606,6 +633,9 @@ describe("IdList Fuzzer Tests", () => {
                   fuzzer = fuzzer.insertAfter(ids[idx], id);
                   ids.push(id);
                 } catch (e) {
+                  if (e instanceof AssertionError) {
+                    throw e;
+                  }
                   // Handle exceptions
                 }
               }
@@ -619,6 +649,9 @@ describe("IdList Fuzzer Tests", () => {
                   fuzzer = fuzzer.insertBefore(ids[idx], id);
                   ids.push(id);
                 } catch (e) {
+                  if (e instanceof AssertionError) {
+                    throw e;
+                  }
                   // Handle exceptions
                 }
               }
@@ -637,6 +670,9 @@ describe("IdList Fuzzer Tests", () => {
                 try {
                   fuzzer = fuzzer.undelete(ids[idx]);
                 } catch (e) {
+                  if (e instanceof AssertionError) {
+                    throw e;
+                  }
                   // Handle exceptions
                 }
               }

--- a/test/basic_fuzz.test.ts
+++ b/test/basic_fuzz.test.ts
@@ -1,6 +1,7 @@
 import seedrandom from "seedrandom";
-import { ElementId } from "../src";
+import { ElementId, IdList } from "../src";
 import { Fuzzer } from "./fuzzer";
+import { IdList as IdListSimple } from "./id_list_simple";
 
 describe("IdList Fuzzer Tests", () => {
   let prng!: seedrandom.PRNG;
@@ -197,6 +198,7 @@ describe("IdList Fuzzer Tests", () => {
                 break;
             }
           } catch (e) {
+            // TODO: remove?
             // Expected exceptions might occur, continue
           }
         }

--- a/test/btree_fuzz.test.ts
+++ b/test/btree_fuzz.test.ts
@@ -517,5 +517,31 @@ describe("IdList B+Tree Specific Fuzz Tests", () => {
         fuzzer.checkAll();
       }
     });
+
+    it("should handle interleaved operations on a deep tree", () => {
+      let fuzzer = Fuzzer.new();
+
+      // Create a deep tree with many elements
+      fuzzer = fuzzer.insertAfter(null, createId("base", 0), 100);
+
+      // Insert elements with varying patterns in the middle
+      for (let i = 0; i < 20; i++) {
+        const baseIndex = 10 + i * 4;
+        fuzzer = fuzzer.insertAfter(
+          createId("base", baseIndex),
+          createId(`interleaved${i}`, 0),
+          (i % 3) + 1 // Insert 1, 2, or 3 elements
+        );
+      }
+      fuzzer.checkAll();
+
+      // Delete some elements to create fragmentation in leaves' presence
+      for (let i = 0; i < 30; i++) {
+        if (i % 7 === 0) {
+          fuzzer = fuzzer.delete(createId("base", i));
+        }
+      }
+      fuzzer.checkAll();
+    });
   });
 });

--- a/test/btree_fuzz.test.ts
+++ b/test/btree_fuzz.test.ts
@@ -1,3 +1,4 @@
+import { AssertionError } from "chai";
 import seedrandom from "seedrandom";
 import { ElementId } from "../src";
 import { Fuzzer } from "./fuzzer";
@@ -212,6 +213,9 @@ describe("IdList B+Tree Specific Fuzz Tests", () => {
                 }
                 ids.push(id);
               } catch (e) {
+                if (e instanceof AssertionError) {
+                  throw e;
+                }
                 // Handle ID collisions
               }
             }
@@ -235,6 +239,9 @@ describe("IdList B+Tree Specific Fuzz Tests", () => {
                   ids.push({ bunchId: id.bunchId, counter: id.counter + i });
                 }
               } catch (e) {
+                if (e instanceof AssertionError) {
+                  throw e;
+                }
                 // Handle ID collisions
               }
             }
@@ -276,6 +283,9 @@ describe("IdList B+Tree Specific Fuzz Tests", () => {
                 try {
                   fuzzer = fuzzer.undelete(ids[idx]);
                 } catch (e) {
+                  if (e instanceof AssertionError) {
+                    throw e;
+                  }
                   // Element might not be deleted
                 }
               }
@@ -488,6 +498,9 @@ describe("IdList B+Tree Specific Fuzz Tests", () => {
             fuzzer = fuzzer.insertBefore(ids[boundary], id);
             ids.push(id);
           } catch (e) {
+            if (e instanceof AssertionError) {
+              throw e;
+            }
             // Handle case where ID is already deleted
           }
         }

--- a/test/btree_fuzz.test.ts
+++ b/test/btree_fuzz.test.ts
@@ -1,0 +1,508 @@
+import seedrandom from "seedrandom";
+import { ElementId } from "../src";
+import { Fuzzer } from "./fuzzer";
+
+describe("IdList B+Tree Specific Fuzz Tests", () => {
+  let prng!: seedrandom.PRNG;
+
+  beforeEach(() => {
+    prng = seedrandom("42");
+  });
+
+  // Helper to create ElementIds
+  const createId = (bunchId: string, counter: number): ElementId => ({
+    bunchId,
+    counter,
+  });
+
+  describe("Node Splitting and Merging", () => {
+    it("should correctly handle splits at various tree levels", function () {
+      this.timeout(10000);
+
+      const M = 8; // B+Tree branching factor in IdList
+      let fuzzer = Fuzzer.new();
+
+      // Start with M elements
+      for (let i = 0; i < M; i++) {
+        const id = createId(`id${i}`, 0);
+        fuzzer =
+          i === 0
+            ? fuzzer.insertAfter(null, id)
+            : fuzzer.insertAfter(createId(`id${i - 1}`, 0), id);
+      }
+
+      fuzzer.checkAll();
+
+      // Force a split by adding one more element
+      fuzzer = fuzzer.insertAfter(
+        createId(`id${M - 1}`, 0),
+        createId(`id${M}`, 0)
+      );
+      fuzzer.checkAll();
+
+      // Now add enough elements to force multiple levels in the tree
+      // First level split typically happens at M elements
+      // Second level split approximately at M² elements
+      const secondLevelSplitTarget = M * M;
+
+      for (let i = M + 1; i < secondLevelSplitTarget + 10; i++) {
+        const id = createId(`id${i}`, 0);
+        fuzzer = fuzzer.insertAfter(createId(`id${i - 1}`, 0), id);
+
+        // Check more frequently near expected split points
+        if (
+          i % M === 0 ||
+          (i >= secondLevelSplitTarget - 5 && i <= secondLevelSplitTarget + 5)
+        ) {
+          fuzzer.checkAll();
+        }
+      }
+
+      fuzzer.checkAll();
+    });
+
+    it("should maintain tree integrity during interleaved insert/delete at boundaries", function () {
+      this.timeout(5000);
+
+      let fuzzer = Fuzzer.new();
+      const M = 8; // B+Tree branching factor
+
+      // Create initial structure with M-1 elements
+      for (let i = 0; i < M - 1; i++) {
+        const id = createId(`id${i}`, 0);
+        fuzzer =
+          i === 0
+            ? fuzzer.insertAfter(null, id)
+            : fuzzer.insertAfter(createId(`id${i - 1}`, 0), id);
+      }
+
+      fuzzer.checkAll();
+
+      // Repeatedly push the structure to M elements (threshold for split),
+      // then delete and reinsert at node boundaries
+      for (let cycle = 0; cycle < 10; cycle++) {
+        // Add element to trigger potential split
+        const triggerSplitId = createId(`trigger${cycle}`, 0);
+        fuzzer = fuzzer.insertAfter(createId(`id${M - 2}`, 0), triggerSplitId);
+        fuzzer.checkAll();
+
+        // Delete from potential boundary points
+        const boundaryIndex = cycle % 3;
+
+        if (boundaryIndex === 0) {
+          // Delete from beginning
+          fuzzer = fuzzer.delete(createId(`id0`, 0));
+        } else if (boundaryIndex === 1) {
+          // Delete from middle
+          fuzzer = fuzzer.delete(createId(`id${Math.floor(M / 2)}`, 0));
+        } else {
+          // Delete from end
+          fuzzer = fuzzer.delete(triggerSplitId);
+        }
+
+        fuzzer.checkAll();
+
+        // Insert at a different boundary
+        const insertIndex = (cycle + 1) % 3;
+        const newId = createId(`insert${cycle}`, 0);
+
+        if (insertIndex === 0) {
+          // Insert at beginning
+          fuzzer = fuzzer.insertBefore(createId(`id1`, 0), newId);
+        } else if (insertIndex === 1) {
+          // Insert in middle
+          const midId = createId(`id${Math.floor(M / 2) + 1}`, 0);
+          fuzzer = fuzzer.insertBefore(midId, newId);
+        } else {
+          // Insert at end
+          fuzzer = fuzzer.insertAfter(createId(`id${M - 2}`, 0), newId);
+        }
+
+        fuzzer.checkAll();
+      }
+    });
+
+    it("should handle bulk insertions that cause complex splits", function () {
+      this.timeout(5000);
+
+      let fuzzer = Fuzzer.new();
+      const M = 8; // B+Tree branching factor
+
+      // Create initial structure with half M elements
+      for (let i = 0; i < M / 2; i++) {
+        const id = createId(`base${i}`, 0);
+        fuzzer =
+          i === 0
+            ? fuzzer.insertAfter(null, id)
+            : fuzzer.insertAfter(createId(`base${i - 1}`, 0), id);
+      }
+
+      fuzzer.checkAll();
+
+      // Insert bulk batches at various positions that will cause splits
+      for (let batch = 0; batch < 5; batch++) {
+        const batchSize = M - 2; // Large enough to cause splits
+        const referenceIdx = Math.floor(prng() * (M / 2));
+        const referenceId = createId(`base${referenceIdx}`, 0);
+        const batchId = createId(`batch${batch}`, 0);
+
+        if (batch % 2 === 0) {
+          fuzzer = fuzzer.insertAfter(referenceId, batchId, batchSize);
+        } else {
+          fuzzer = fuzzer.insertBefore(referenceId, batchId, batchSize);
+        }
+
+        fuzzer.checkAll();
+      }
+    });
+  });
+
+  describe("Complex Tree Operations", () => {
+    it("should handle deep tree restructuring with mixed operations", function () {
+      this.timeout(10000);
+
+      const operationCount = 100; // Parameter to adjust test intensity
+      let fuzzer = Fuzzer.new();
+      const ids: ElementId[] = [];
+
+      // First create a tree large enough to have multiple levels
+      for (let i = 0; i < 50; i++) {
+        const id = createId(`base${i}`, 0);
+        if (i === 0) {
+          fuzzer = fuzzer.insertAfter(null, id);
+        } else {
+          fuzzer = fuzzer.insertAfter(ids[i - 1], id);
+        }
+        ids.push(id);
+
+        if (i % 10 === 0) {
+          fuzzer.checkAll();
+        }
+      }
+
+      fuzzer.checkAll();
+
+      // Now perform random operations targeting different tree levels
+      for (let op = 0; op < operationCount; op++) {
+        const operation = Math.floor(prng() * 4);
+
+        if (op % 10 === 0) {
+          fuzzer.checkAll();
+        }
+
+        switch (operation) {
+          case 0: // Insert at start/middle/end
+            {
+              const position = Math.floor(prng() * 3); // 0=start, 1=middle, 2=end
+              const id = createId(`op${op}`, 0);
+
+              try {
+                if (position === 0) {
+                  // Insert at start
+                  fuzzer = fuzzer.insertBefore(ids[0], id);
+                } else if (position === 1) {
+                  // Insert in middle
+                  const midIdx =
+                    Math.floor(ids.length / 2) + Math.floor(prng() * 10) - 5;
+                  const refIdx = Math.max(0, Math.min(ids.length - 1, midIdx));
+                  fuzzer = fuzzer.insertAfter(ids[refIdx], id);
+                } else {
+                  // Insert at end
+                  fuzzer = fuzzer.insertAfter(ids[ids.length - 1], id);
+                }
+                ids.push(id);
+              } catch (e) {
+                // Handle ID collisions
+              }
+            }
+            break;
+
+          case 1: // Insert multiple elements
+            {
+              const count = 1 + Math.floor(prng() * 10); // 1-10 elements
+              const refIdx = Math.floor(prng() * ids.length);
+              const id = createId(`bulk${op}`, 0);
+
+              try {
+                if (prng() > 0.5) {
+                  fuzzer = fuzzer.insertAfter(ids[refIdx], id, count);
+                } else {
+                  fuzzer = fuzzer.insertBefore(ids[refIdx], id, count);
+                }
+
+                // Add new IDs to known list
+                for (let i = 0; i < count; i++) {
+                  ids.push({ bunchId: id.bunchId, counter: id.counter + i });
+                }
+              } catch (e) {
+                // Handle ID collisions
+              }
+            }
+            break;
+
+          case 2: // Delete in patterns
+            {
+              const pattern = Math.floor(prng() * 3); // 0=start, 1=every-nth, 2=range
+
+              if (pattern === 0 && ids.length > 10) {
+                // Delete first few elements
+                const count = 1 + Math.floor(prng() * 3); // 1-3 elements
+                for (let i = 0; i < count; i++) {
+                  fuzzer = fuzzer.delete(ids[i]);
+                }
+              } else if (pattern === 1 && ids.length > 10) {
+                // Delete every nth element
+                const nth = 2 + Math.floor(prng() * 5); // Every 2nd to 6th
+                for (let i = 0; i < ids.length; i += nth) {
+                  fuzzer = fuzzer.delete(ids[i]);
+                }
+              } else if (ids.length > 10) {
+                // Delete a range
+                const start = Math.floor(prng() * (ids.length / 2));
+                const count = 1 + Math.floor(prng() * 5); // 1-5 elements
+                for (let i = 0; i < count && start + i < ids.length; i++) {
+                  fuzzer = fuzzer.delete(ids[start + i]);
+                }
+              }
+            }
+            break;
+
+          case 3: // Undelete
+            {
+              // Undelete a few random elements
+              const count = 1 + Math.floor(prng() * 3); // 1-3 elements
+              for (let i = 0; i < count; i++) {
+                const idx = Math.floor(prng() * ids.length);
+                try {
+                  fuzzer = fuzzer.undelete(ids[idx]);
+                } catch (e) {
+                  // Element might not be deleted
+                }
+              }
+            }
+            break;
+        }
+      }
+
+      fuzzer.checkAll();
+    });
+
+    it("should maintain tree integrity with sequential run operations", function () {
+      this.timeout(5000);
+
+      let fuzzer = Fuzzer.new();
+
+      // Create sequential runs with same bunchId but varying patterns
+      // This tests the compression and run handling logic
+
+      // First create a base run
+      fuzzer = fuzzer.insertAfter(null, createId("run", 0), 20);
+      fuzzer.checkAll();
+
+      // Delete elements to create gaps in the run
+      const deletePatterns = [
+        [1, 5, 9, 13, 17], // Every 4th element
+        [3, 4], // Small contiguous range
+        [10, 11, 12, 13, 14, 15], // Large contiguous range
+      ];
+
+      for (const pattern of deletePatterns) {
+        for (const idx of pattern) {
+          fuzzer = fuzzer.delete(createId("run", idx));
+        }
+        fuzzer.checkAll();
+      }
+
+      // Insert elements that extend the run
+      fuzzer = fuzzer.insertAfter(createId("run", 19), createId("run", 20), 10);
+      fuzzer.checkAll();
+
+      // Insert elements that create a gap, then fill it
+      fuzzer = fuzzer.insertAfter(createId("run", 29), createId("run", 40), 10);
+      fuzzer.checkAll();
+
+      // Fill the gap
+      fuzzer = fuzzer.insertAfter(createId("run", 29), createId("run", 30), 10);
+      fuzzer.checkAll();
+
+      // Delete elements at the boundaries
+      fuzzer = fuzzer.delete(createId("run", 0));
+      fuzzer = fuzzer.delete(createId("run", 19));
+      fuzzer = fuzzer.delete(createId("run", 20));
+      fuzzer = fuzzer.delete(createId("run", 29));
+      fuzzer = fuzzer.delete(createId("run", 30));
+      fuzzer = fuzzer.delete(createId("run", 49));
+      fuzzer.checkAll();
+
+      // Undelete some elements
+      fuzzer = fuzzer.undelete(createId("run", 0));
+      fuzzer = fuzzer.undelete(createId("run", 29));
+      fuzzer = fuzzer.undelete(createId("run", 49));
+      fuzzer.checkAll();
+    });
+  });
+
+  describe("Edge Cases and Tree Balancing", () => {
+    it("should handle interleaved sequences that affect leaf structure", function () {
+      this.timeout(5000);
+
+      let fuzzer = Fuzzer.new();
+      const ids: ElementId[] = [];
+
+      // Create an interleaved sequence of different bunchIds
+      // This creates a more complex leaf structure
+      for (let i = 0; i < 30; i++) {
+        const bunchId = `bunch${i % 5}`; // Use 5 different bunchIds
+        const counter = Math.floor(i / 5);
+        const id = createId(bunchId, counter);
+
+        if (i === 0) {
+          fuzzer = fuzzer.insertAfter(null, id);
+        } else {
+          fuzzer = fuzzer.insertAfter(ids[ids.length - 1], id);
+        }
+
+        ids.push(id);
+      }
+
+      fuzzer.checkAll();
+
+      // Delete elements in a pattern that affects multiple bunches
+      for (let i = 0; i < 30; i += 6) {
+        fuzzer = fuzzer.delete(ids[i]);
+      }
+
+      fuzzer.checkAll();
+
+      // Insert elements between existing ones
+      for (let i = 0; i < 10; i++) {
+        const insertIdx = 2 * i + 1;
+        if (insertIdx < ids.length) {
+          const id = createId(`insert${i}`, 0);
+          fuzzer = fuzzer.insertAfter(ids[insertIdx], id);
+          ids.push(id);
+        }
+      }
+
+      fuzzer.checkAll();
+
+      // Merge sequences by inserting elements with matching bunchIds
+      for (let i = 0; i < 5; i++) {
+        // Find the last element with this bunchId
+        let lastIdx = -1;
+        let lastCounter = -1;
+        for (let j = ids.length - 1; j >= 0; j--) {
+          if (ids[j].bunchId === `bunch${i}`) {
+            lastIdx = j;
+            lastCounter = ids[j].counter;
+            break;
+          }
+        }
+
+        if (lastIdx >= 0) {
+          // Insert elements that continue the sequence
+          const id = createId(`bunch${i}`, lastCounter + 1);
+          fuzzer = fuzzer.insertAfter(ids[lastIdx], id, 3);
+
+          for (let j = 0; j < 3; j++) {
+            ids.push({ bunchId: id.bunchId, counter: id.counter + j });
+          }
+        }
+      }
+
+      fuzzer.checkAll();
+    });
+
+    it("should test the impact of bulk operations on tree balance", function () {
+      this.timeout(10000);
+
+      // Parameter to control test intensity
+      const batchCount = 5;
+      const batchSize = 20;
+
+      let fuzzer = Fuzzer.new();
+      const ids: ElementId[] = [];
+
+      // Add batches of elements that will force the tree to grow
+      for (let batch = 0; batch < batchCount; batch++) {
+        const batchId = createId(`batch${batch}`, 0);
+
+        // Choose where to insert the batch
+        if (batch === 0 || ids.length === 0) {
+          // First batch at the beginning
+          fuzzer = fuzzer.insertAfter(null, batchId, batchSize);
+        } else if (batch === 1) {
+          // Second batch at the end
+          fuzzer = fuzzer.insertAfter(ids[ids.length - 1], batchId, batchSize);
+        } else {
+          // Other batches at random positions
+          const position = Math.floor(prng() * ids.length);
+          if (prng() > 0.5) {
+            fuzzer = fuzzer.insertAfter(ids[position], batchId, batchSize);
+          } else {
+            fuzzer = fuzzer.insertBefore(ids[position], batchId, batchSize);
+          }
+        }
+
+        // Add the batch IDs to our tracking
+        for (let i = 0; i < batchSize; i++) {
+          ids.push({ bunchId: batchId.bunchId, counter: batchId.counter + i });
+        }
+
+        fuzzer.checkAll();
+
+        // Now delete a fraction of elements from previous batches
+        if (batch > 0) {
+          const deleteCount = Math.floor(batchSize / 4); // Delete 25% of a batch
+          const targetBatch = Math.floor(prng() * batch); // Choose a previous batch
+
+          // Delete elements from the target batch
+          for (let i = 0; i < deleteCount; i++) {
+            const deletePosition = targetBatch * batchSize + i * 2; // Delete every other element
+            if (deletePosition < ids.length) {
+              fuzzer = fuzzer.delete(ids[deletePosition]);
+            }
+          }
+
+          fuzzer.checkAll();
+        }
+      }
+
+      // Now perform targeted operations that might affect balance
+
+      // 1. Delete elements at potential node boundaries
+      const boundaryCandidates = [0, 8, 16, 24, 32, 40, 48, 56];
+      for (const boundary of boundaryCandidates) {
+        if (boundary < ids.length) {
+          fuzzer = fuzzer.delete(ids[boundary]);
+        }
+      }
+
+      fuzzer.checkAll();
+
+      // 2. Insert elements at those same boundaries
+      for (const boundary of boundaryCandidates) {
+        if (boundary < ids.length) {
+          const id = createId(`boundary${boundary}`, 0);
+          try {
+            fuzzer = fuzzer.insertBefore(ids[boundary], id);
+            ids.push(id);
+          } catch (e) {
+            // Handle case where ID is already deleted
+          }
+        }
+      }
+
+      fuzzer.checkAll();
+
+      // 3. Bulk operation to insert a large batch in the middle
+      if (ids.length > 20) {
+        const midpoint = Math.floor(ids.length / 2);
+        const id = createId("middle", 0);
+        fuzzer = fuzzer.insertAfter(ids[midpoint], id, 30);
+
+        fuzzer.checkAll();
+      }
+    });
+  });
+});

--- a/test/btree_implementation.test.ts
+++ b/test/btree_implementation.test.ts
@@ -76,7 +76,7 @@ describe("IdList B+Tree Implementation", () => {
       let list = IdList.new();
 
       // Insert exactly M elements (where M=8 is the branching factor)
-      for (let i = 0; i < 8; i++) {
+      for (let i = 0; i < M; i++) {
         list = list.insertAfter(null, createId(`id${i}`, 0));
       }
 
@@ -101,7 +101,7 @@ describe("IdList B+Tree Implementation", () => {
       }
 
       // Verify all elements are still accessible and in the correct order
-      for (let i = 0; i < 8; i++) {
+      for (let i = 0; i < M; i++) {
         expect(list.has(createId(`id${i}`, 0))).to.be.true;
         expect(list.indexOf(createId(`id${i}`, 0))).to.equal(i);
       }

--- a/test/btree_implementation.test.ts
+++ b/test/btree_implementation.test.ts
@@ -1,0 +1,453 @@
+import { assert, expect } from "chai";
+import { ElementId, IdList } from "../src";
+
+describe("IdList B+Tree Implementation", () => {
+  // Helper to create ElementIds
+  const createId = (bunchId: string, counter: number): ElementId => ({
+    bunchId,
+    counter,
+  });
+
+  describe("Tree Structure and Balancing", () => {
+    it("should maintain balanced structure after many insertions", () => {
+      let list = IdList.new();
+
+      // Insert enough elements to force multiple levels in the B+Tree
+      // M = 8, so we'll insert more than enough to cause splits
+      for (let i = 0; i < 100; i++) {
+        list = list.insertAfter(null, createId(`id${i}`, 0));
+      }
+
+      // Access the root to examine the tree structure
+      // @ts-expect-error Accessing private field
+      const root = list["root"];
+
+      // Helper to check node properties recursively
+      function checkNodeProperties(
+        node,
+        depth = 0
+      ): { height: number; maxChildren: number } {
+        // No node should exceed the branching factor M (8)
+        expect(node.children.length).to.be.at.most(8);
+
+        // If this is an inner node (has children that have children)
+        if (node.children.length > 0 && node.children[0].children) {
+          // Check all children and get their heights
+          const childStats = node.children.map((child) =>
+            checkNodeProperties(child, depth + 1)
+          );
+
+          // All children should have the same height (balanced tree property)
+          const heights = childStats.map((s) => s.height);
+          const firstHeight = heights[0];
+          expect(
+            heights.every((h) => h === firstHeight),
+            "Children heights should be equal"
+          ).to.be.true;
+
+          // Return this node's height and max children count
+          return {
+            height: 1 + firstHeight,
+            maxChildren: Math.max(
+              node.children.length,
+              ...childStats.map((s) => s.maxChildren)
+            ),
+          };
+        } else {
+          // Leaf level or level just above leaves
+          return { height: 1, maxChildren: node.children.length };
+        }
+      }
+
+      const treeStats = checkNodeProperties(root);
+
+      // For 100 elements with M=8, expected height would be around 3 or 4
+      // ⌈log_8(100)⌉ is approximately 3
+      expect(treeStats.height).to.be.greaterThan(1);
+
+      // Verify all elements are accessible
+      for (let i = 0; i < 100; i++) {
+        expect(list.has(createId(`id${i}`, 0))).to.be.true;
+        expect(list.indexOf(createId(`id${i}`, 0))).to.equal(i);
+      }
+    });
+
+    it("should force a node split when exceeding the branching factor", () => {
+      let list = IdList.new();
+
+      // Insert exactly M elements (where M=8 is the branching factor)
+      for (let i = 0; i < 8; i++) {
+        list = list.insertAfter(null, createId(`id${i}`, 0));
+      }
+
+      // @ts-expect-error Accessing private field
+      const beforeSplit = list["root"];
+
+      // Insert one more element to force a split
+      list = list.insertAfter(null, createId("split", 0));
+
+      // @ts-expect-error Accessing private field
+      const afterSplit = list["root"];
+
+      // After a split, we should have a different root structure
+      expect(afterSplit).to.not.deep.equal(beforeSplit);
+
+      // Specifically, we should now have inner nodes if we didn't before
+      // Or more children in the inner nodes if we already had them
+      if (!beforeSplit.children[0].children) {
+        expect(afterSplit.children[0].children).to.exist;
+      } else {
+        expect(afterSplit.children.length).to.not.equal(
+          beforeSplit.children.length
+        );
+      }
+
+      // Verify all elements are still accessible and in the correct order
+      for (let i = 0; i < 8; i++) {
+        expect(list.has(createId(`id${i}`, 0))).to.be.true;
+        expect(list.indexOf(createId(`id${i}`, 0))).to.equal(i);
+      }
+      expect(list.has(createId("split", 0))).to.be.true;
+    });
+  });
+
+  describe("Leaf Node Splitting", () => {
+    it("should correctly split a leaf when inserting in the middle", () => {
+      let list = IdList.new();
+
+      // Insert sequential elements in a single bunch (single leaf)
+      list = list.insertAfter(null, createId("bunch", 0), 6);
+
+      // Insert in the middle of the leaf to force a split
+      list = list.insertAfter(createId("bunch", 2), createId("middle", 0));
+
+      // Verify the order is correct after split
+      expect(list.at(0)).to.deep.equal(createId("bunch", 0));
+      expect(list.at(1)).to.deep.equal(createId("bunch", 1));
+      expect(list.at(2)).to.deep.equal(createId("bunch", 2));
+      expect(list.at(3)).to.deep.equal(createId("middle", 0));
+      expect(list.at(4)).to.deep.equal(createId("bunch", 3));
+      expect(list.at(5)).to.deep.equal(createId("bunch", 4));
+      expect(list.at(6)).to.deep.equal(createId("bunch", 5));
+
+      // Verify we can still locate all elements
+      for (let i = 0; i < 6; i++) {
+        if (i < 3) {
+          expect(list.indexOf(createId("bunch", i))).to.equal(i);
+        } else {
+          expect(list.indexOf(createId("bunch", i))).to.equal(i + 1);
+        }
+      }
+      expect(list.indexOf(createId("middle", 0))).to.equal(3);
+    });
+
+    it("should handle multiple splits in a complex insertion pattern", () => {
+      let list = IdList.new();
+
+      // Insert a bunch of sequential IDs
+      list = list.insertAfter(null, createId("seq", 0), 15);
+
+      // Now cause splits by inserting elements between every other element
+      for (let i = 0; i < 7; i++) {
+        list = list.insertAfter(createId("seq", i * 2), createId("insert", i));
+      }
+
+      // Verify all elements are in the correct order
+      for (let i = 0; i < 15; i++) {
+        const expectedPosition = i + Math.floor(i / 2);
+        expect(list.indexOf(createId("seq", i))).to.equal(expectedPosition);
+
+        if (i % 2 === 0 && i < 14) {
+          expect(list.indexOf(createId("insert", i / 2))).to.equal(
+            i + Math.floor(i / 2) + 1
+          );
+        }
+      }
+
+      // Verify total length
+      expect(list.length).to.equal(15 + 7);
+    });
+
+    it("should handle insertion at leaf boundaries", () => {
+      let list = IdList.new();
+
+      // Create a list where elements are likely to be distributed across multiple leaves
+      // Using different bunchIds to prevent run compression
+      for (let i = 0; i < 20; i++) {
+        list = list.insertAfter(
+          i === 0 ? null : createId(`id${i - 1}`, 0),
+          createId(`id${i}`, 0)
+        );
+      }
+
+      // Now insert at likely leaf boundaries (around multiples of M=8)
+      list = list.insertBefore(createId("id8", 0), createId("boundary1", 0));
+      list = list.insertBefore(createId("id16", 0), createId("boundary2", 0));
+
+      // Verify the insertions worked correctly
+      expect(list.indexOf(createId("boundary1", 0))).to.equal(8);
+      expect(list.indexOf(createId("id8", 0))).to.equal(9);
+      expect(list.indexOf(createId("boundary2", 0))).to.equal(17);
+      expect(list.indexOf(createId("id16", 0))).to.equal(18);
+    });
+  });
+
+  describe("Sequential ID Compression and Storage", () => {
+    it("should compress sequential IDs in the same bunch", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Save state and check compression
+      const saved = list.save();
+
+      // Should be compressed into a single entry
+      expect(saved.length).to.equal(1);
+      expect(saved[0]).to.deep.equal({
+        bunchId: "bunch",
+        startCounter: 0,
+        count: 10,
+        isDeleted: false,
+      });
+
+      // Load and verify
+      const loaded = IdList.load(saved);
+      expect(loaded.length).to.equal(10);
+
+      for (let i = 0; i < 10; i++) {
+        expect(loaded.has(createId("bunch", i))).to.be.true;
+      }
+    });
+
+    it("should preserve compression after complex operations", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Delete elements in the middle
+      list = list.delete(createId("bunch", 3));
+      list = list.delete(createId("bunch", 4));
+      list = list.delete(createId("bunch", 5));
+
+      // Insert different IDs
+      list = list.insertAfter(createId("bunch", 2), createId("other", 0));
+
+      // Save and check compression
+      const saved = list.save();
+
+      // Check how many entries exist for the "bunch" ID
+      const bunchEntries = saved.filter((e) => e.bunchId === "bunch");
+
+      // We should have efficient compression (at most 3 entries for "bunch")
+      expect(bunchEntries.length).to.be.lessThanOrEqual(3);
+
+      // Verify all elements are preserved after load
+      const loaded = IdList.load(saved);
+
+      expect(loaded.has(createId("bunch", 0))).to.be.true;
+      expect(loaded.has(createId("bunch", 1))).to.be.true;
+      expect(loaded.has(createId("bunch", 2))).to.be.true;
+      expect(loaded.has(createId("other", 0))).to.be.true;
+      expect(loaded.has(createId("bunch", 3))).to.be.false;
+      expect(loaded.has(createId("bunch", 4))).to.be.false;
+      expect(loaded.has(createId("bunch", 5))).to.be.false;
+      expect(loaded.has(createId("bunch", 6))).to.be.true;
+      expect(loaded.has(createId("bunch", 7))).to.be.true;
+      expect(loaded.has(createId("bunch", 8))).to.be.true;
+      expect(loaded.has(createId("bunch", 9))).to.be.true;
+    });
+  });
+
+  describe("Edge Cases and Boundary Conditions", () => {
+    it("should handle extending runs with insertions at boundaries", () => {
+      let list = IdList.new();
+
+      // Create a run
+      list = list.insertAfter(null, createId("bunch", 5), 5); // IDs 5-9
+
+      // Extend backward (should merge with existing)
+      list = list.insertBefore(createId("bunch", 5), createId("bunch", 3), 2); // IDs 3-4
+
+      // Extend forward (should merge with existing)
+      list = list.insertAfter(createId("bunch", 9), createId("bunch", 10), 2); // IDs 10-11
+
+      // Verify all elements are present in the right order
+      for (let i = 3; i <= 11; i++) {
+        expect(list.has(createId("bunch", i))).to.be.true;
+        expect(list.indexOf(createId("bunch", i))).to.equal(i - 3);
+      }
+
+      // Save and check compression
+      const saved = list.save();
+
+      // Should be a single entry due to run merging
+      const bunchEntries = saved.filter((e) => e.bunchId === "bunch");
+      expect(bunchEntries.length).to.equal(1);
+      expect(bunchEntries[0].startCounter).to.equal(3);
+      expect(bunchEntries[0].count).to.equal(9); // IDs 3-11 (9 elements)
+    });
+
+    it("should correctly handle the locate function with deleted elements", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Delete some elements
+      list = list.delete(createId("bunch", 3));
+      list = list.delete(createId("bunch", 6));
+
+      // Elements should still be locatable
+      expect(list.isKnown(createId("bunch", 3))).to.be.true;
+      expect(list.isKnown(createId("bunch", 6))).to.be.true;
+
+      // indexOf with different bias values
+      expect(list.indexOf(createId("bunch", 3), "none")).to.equal(-1);
+      expect(list.indexOf(createId("bunch", 3), "left")).to.equal(2);
+      expect(list.indexOf(createId("bunch", 3), "right")).to.equal(3);
+
+      expect(list.indexOf(createId("bunch", 6), "none")).to.equal(-1);
+      expect(list.indexOf(createId("bunch", 6), "left")).to.equal(4);
+      expect(list.indexOf(createId("bunch", 6), "right")).to.equal(5);
+
+      // Undelete and check again
+      list = list.undelete(createId("bunch", 3));
+      expect(list.has(createId("bunch", 3))).to.be.true;
+      expect(list.indexOf(createId("bunch", 3))).to.equal(3);
+    });
+
+    it("should handle insertions in empty lists", () => {
+      // Empty list insertAfter with null
+      let list1 = IdList.new().insertAfter(null, createId("first", 0));
+      expect(list1.length).to.equal(1);
+      expect(list1.at(0)).to.deep.equal(createId("first", 0));
+
+      // Empty list insertBefore with null
+      let list2 = IdList.new().insertBefore(null, createId("first", 0));
+      expect(list2.length).to.equal(1);
+      expect(list2.at(0)).to.deep.equal(createId("first", 0));
+    });
+
+    it("should handle very large bulk insertions", () => {
+      let list = IdList.new();
+
+      // Insert a large number of sequential IDs
+      const largeCount = 1000;
+      list = list.insertAfter(null, createId("bulk", 0), largeCount);
+
+      // Verify all elements are accessible
+      expect(list.length).to.equal(largeCount);
+
+      // Check some elements at various indices
+      expect(list.at(0)).to.deep.equal(createId("bulk", 0));
+      expect(list.at(largeCount - 1)).to.deep.equal(
+        createId("bulk", largeCount - 1)
+      );
+      expect(list.at(largeCount / 2)).to.deep.equal(
+        createId("bulk", largeCount / 2)
+      );
+
+      // Check that the operation was efficient by examining the save format
+      const saved = list.save();
+      expect(saved.length).to.equal(1); // Should be compressed to a single entry
+    });
+  });
+
+  describe("Advanced Operations and Combined Cases", () => {
+    it("should maintain tree integrity with complex insertion/deletion patterns", () => {
+      let list = IdList.new();
+
+      // Create a pattern of IDs with differing bunchIds to test tree integrity
+      for (let i = 0; i < 50; i++) {
+        // Use alternating bunch IDs
+        const bunchId = i % 2 === 0 ? "even" : "odd";
+        const id = createId(bunchId, Math.floor(i / 2));
+
+        if (i === 0) {
+          list = list.insertAfter(null, id);
+        } else {
+          const prevId = list.at(i - 1);
+          list = list.insertAfter(prevId, id);
+        }
+      }
+
+      // Delete every third element to fragment the tree
+      for (let i = 0; i < 50; i += 3) {
+        if (i < list.length) {
+          list = list.delete(list.at(i));
+        }
+      }
+
+      // Insert new elements in the middle
+      const middleId = list.at(Math.floor(list.length / 2));
+      list = list.insertAfter(middleId, createId("middle", 0), 5);
+
+      // Verify the tree still provides correct answers
+      const allIds = [...list];
+
+      // Check the length is correct
+      const expectedLength = 50 - Math.ceil(50 / 3) + 5;
+      expect(list.length).to.equal(allIds.length);
+      expect(list.length).to.be.closeTo(expectedLength, 1);
+
+      // Check that all middle elements were inserted together
+      const middleIndices = [];
+      for (let i = 0; i < 5; i++) {
+        middleIndices.push(list.indexOf(createId("middle", i)));
+      }
+
+      // The middle indices should be consecutive
+      for (let i = 1; i < middleIndices.length; i++) {
+        expect(middleIndices[i]).to.equal(middleIndices[i - 1] + 1);
+      }
+    });
+
+    it("should handle interleaved operations on a deep tree", () => {
+      let list = IdList.new();
+
+      // Create a deep tree with many elements
+      list = list.insertAfter(null, createId("base", 0), 100);
+
+      // Insert elements with varying patterns in the middle
+      for (let i = 0; i < 20; i++) {
+        const baseIndex = 10 + i * 4;
+        list = list.insertAfter(
+          createId("base", baseIndex),
+          createId(`interleaved${i}`, 0),
+          (i % 3) + 1 // Insert 1, 2, or 3 elements
+        );
+      }
+
+      // Delete some elements to create fragmentation
+      for (let i = 0; i < 30; i++) {
+        if (i % 7 === 0) {
+          list = list.delete(createId("base", i));
+        }
+      }
+
+      // Verify elements are still accessible in the correct order
+      let expectedIndex = 0;
+      for (let i = 0; i < 100; i++) {
+        if (i % 7 === 0) {
+          // This element is deleted
+          expect(list.has(createId("base", i))).to.be.false;
+        } else {
+          expect(list.has(createId("base", i))).to.be.true;
+
+          // Check position - need to account for interleaved insertions
+          const basePos = list.indexOf(createId("base", i));
+          if (i >= 10 && i < 90 && (i - 10) % 4 === 0) {
+            // An insertion point - check the interleaved elements
+            const interleaveIndex = Math.floor((i - 10) / 4);
+            for (let j = 0; j < (interleaveIndex % 3) + 1; j++) {
+              expect(list.has(createId(`interleaved${interleaveIndex}`, j))).to
+                .be.true;
+            }
+          }
+        }
+      }
+    });
+  });
+});

--- a/test/btree_implementation.test.ts
+++ b/test/btree_implementation.test.ts
@@ -68,6 +68,17 @@ describe("IdList B+Tree Implementation", () => {
       for (let i = 0; i < 100; i++) {
         expect(list.has(createId(`id${i}`, 0))).to.be.true;
         expect(list.indexOf(createId(`id${i}`, 0))).to.equal(i);
+        expect(list.knownIds.indexOf(createId(`id${i}`, 0))).to.equal(i);
+      }
+
+      // To test knownIds.indexOf, delete some elements and check again.
+      for (let i = 0; i < 100; i += 5) {
+        list = list.delete(createId(`id${i}`, 0));
+      }
+      for (let i = 0; i < 100; i++) {
+        expect(list.has(createId(`id${i}`, 0))).to.equal(i % 5 !== 0);
+        expect(list.isKnown(createId(`id${i}`, 0))).to.be.true;
+        expect(list.knownIds.indexOf(createId(`id${i}`, 0))).to.equal(i);
       }
     });
 
@@ -107,7 +118,7 @@ describe("IdList B+Tree Implementation", () => {
   });
 
   describe("Leaf Node Splitting", () => {
-    it("should correctly split a leaf when inserting in the middle", () => {
+    it("should correctly split a leaf when inserting after in the middle", () => {
       let list = IdList.new();
 
       // Insert sequential elements in a single bunch (single leaf)
@@ -136,7 +147,34 @@ describe("IdList B+Tree Implementation", () => {
       expect(list.indexOf(createId("middle", 0))).to.equal(3);
     });
 
-    // TODO: Also test splitting presence (partially deleted starting bunch).
+    it("should correctly split a leaf when inserting before in the middle", () => {
+      let list = IdList.new();
+
+      // Insert sequential elements in a single bunch (single leaf)
+      list = list.insertAfter(null, createId("bunch", 0), 6);
+
+      // Insert in the middle of the leaf to force a split
+      list = list.insertBefore(createId("bunch", 3), createId("middle", 0));
+
+      // Verify the order is correct after split
+      expect(list.at(0)).to.deep.equal(createId("bunch", 0));
+      expect(list.at(1)).to.deep.equal(createId("bunch", 1));
+      expect(list.at(2)).to.deep.equal(createId("bunch", 2));
+      expect(list.at(3)).to.deep.equal(createId("middle", 0));
+      expect(list.at(4)).to.deep.equal(createId("bunch", 3));
+      expect(list.at(5)).to.deep.equal(createId("bunch", 4));
+      expect(list.at(6)).to.deep.equal(createId("bunch", 5));
+
+      // Verify we can still locate all elements
+      for (let i = 0; i < 6; i++) {
+        if (i < 3) {
+          expect(list.indexOf(createId("bunch", i))).to.equal(i);
+        } else {
+          expect(list.indexOf(createId("bunch", i))).to.equal(i + 1);
+        }
+      }
+      expect(list.indexOf(createId("middle", 0))).to.equal(3);
+    });
 
     it("should handle multiple splits in a complex insertion pattern", () => {
       let list = IdList.new();

--- a/test/btree_implementation.test.ts
+++ b/test/btree_implementation.test.ts
@@ -105,8 +105,8 @@ describe("IdList B+Tree Implementation", () => {
       const [newLeft, newRight] = afterSplit.children as InnerNodeLeaf[];
       expect(newLeft).to.be.instanceOf(InnerNodeLeaf);
       expect(newRight).to.be.instanceOf(InnerNodeLeaf);
-      expect(newLeft.children).to.have.length(M / 2);
-      expect(newRight.children).to.have.length(M / 2 + 1);
+      expect(newLeft.children).to.have.length(M / 2 + 1);
+      expect(newRight.children).to.have.length(M / 2);
 
       // Verify all elements are still accessible and in the correct order
       for (let i = 0; i < M; i++) {

--- a/test/btree_implementation.test.ts
+++ b/test/btree_implementation.test.ts
@@ -461,52 +461,5 @@ describe("IdList B+Tree Implementation", () => {
         expect(middleIndices[i]).to.equal(middleIndices[i - 1] + 1);
       }
     });
-
-    // TODO: Convert to fuzz test.
-    it.skip("should handle interleaved operations on a deep tree", () => {
-      let list = IdList.new();
-
-      // Create a deep tree with many elements
-      list = list.insertAfter(null, createId("base", 0), 100);
-
-      // Insert elements with varying patterns in the middle
-      for (let i = 0; i < 20; i++) {
-        const baseIndex = 10 + i * 4;
-        list = list.insertAfter(
-          createId("base", baseIndex),
-          createId(`interleaved${i}`, 0),
-          (i % 3) + 1 // Insert 1, 2, or 3 elements
-        );
-      }
-
-      // Delete some elements to create fragmentation in leaves' presence
-      for (let i = 0; i < 30; i++) {
-        if (i % 7 === 0) {
-          list = list.delete(createId("base", i));
-        }
-      }
-
-      // Verify elements are still accessible in the correct order
-      const expectedIndex = 0;
-      for (let i = 0; i < 100; i++) {
-        if (i % 7 === 0 && i < 30) {
-          // This element is deleted
-          expect(list.has(createId("base", i))).to.be.false;
-        } else {
-          expect(list.has(createId("base", i))).to.be.true;
-
-          // Check position - need to account for interleaved insertions
-          const basePos = list.indexOf(createId("base", i));
-          if (i >= 10 && i < 90 && (i - 10) % 4 === 0) {
-            // An insertion point - check the interleaved elements
-            const interleaveIndex = Math.floor((i - 10) / 4);
-            for (let j = 0; j < (interleaveIndex % 3) + 1; j++) {
-              expect(list.has(createId(`interleaved${interleaveIndex}`, j))).to
-                .be.true;
-            }
-          }
-        }
-      }
-    });
   });
 });

--- a/test/btree_implementation.test.ts
+++ b/test/btree_implementation.test.ts
@@ -417,9 +417,6 @@ describe("IdList B+Tree Implementation", () => {
       const saved = list.save();
       expect(saved.length).to.equal(1); // Should be compressed to a single entry
     });
-
-    // TODO: If you insert separated counters in a bunch (e.g. 0, 2, 1), it won't merge the leaves.
-    // Could be okay (perf penalty for doing silly things) but it may mess up the saved states.
   });
 
   describe("Advanced Operations and Combined Cases", () => {

--- a/test/btree_structure_and_edge_cases.test.ts
+++ b/test/btree_structure_and_edge_cases.test.ts
@@ -1,0 +1,415 @@
+import { expect } from "chai";
+import { ElementId, IdList } from "../src";
+
+describe("IdList Internal Structure", () => {
+  // Helper to create ElementIds
+  const createId = (bunchId: string, counter: number): ElementId => ({
+    bunchId,
+    counter,
+  });
+
+  describe("locate function and traversal", () => {
+    it("should correctly locate elements after tree restructuring", () => {
+      let list = IdList.new();
+
+      // Insert enough elements to force multiple levels in the B+Tree
+      const ids = [];
+      for (let i = 0; i < 50; i++) {
+        const id = createId(`id${i}`, 0);
+        ids.push(id);
+        list = list.insertAfter(i === 0 ? null : ids[i - 1], id);
+      }
+
+      // Access internal locate function
+      // @ts-expect-error Accessing private function and field
+      const locate = Function("return this.locate")().bind(null);
+      // @ts-expect-error Accessing private field
+      const root = list["root"];
+
+      // Verify locate works for all elements
+      for (let i = 0; i < 50; i++) {
+        const path = locate(ids[i], root);
+        expect(path).to.not.be.null;
+        expect(path?.length).to.be.greaterThan(0);
+
+        // First item in path should be the leaf containing our id
+        expect(path?.[0].node.bunchId).to.equal(`id${i}`);
+        expect(path?.[0].node.startCounter).to.equal(0);
+      }
+
+      // Test locate on an unknown element
+      const unknownId = createId("unknown", 0);
+      const unknownPath = locate(unknownId, root);
+      expect(unknownPath).to.be.null;
+    });
+
+    it("should correctly update paths after insertions and splits", () => {
+      let list = IdList.new();
+
+      // Insert elements to create a specific structure
+      for (let i = 0; i < 20; i++) {
+        list = list.insertAfter(null, createId(`id${i}`, 0));
+      }
+
+      // Find the path to an element in the middle
+      const middleId = createId("id10", 0);
+      // @ts-expect-error Accessing private function and field
+      const locate = Function("return this.locate")().bind(null);
+      // @ts-expect-error Accessing private field
+      let root = list["root"];
+      let path = locate(middleId, root);
+
+      // Remember the leaf node that contains middleId
+      const originalLeaf = path?.[0].node;
+
+      // Insert many elements after middleId to force a split
+      for (let i = 0; i < 10; i++) {
+        list = list.insertAfter(middleId, createId(`split${i}`, 0));
+
+        // After each insertion, re-check the path
+        // @ts-expect-error Accessing private field
+        root = list["root"];
+        path = locate(middleId, root);
+
+        // The element should still be locatable
+        expect(path).to.not.be.null;
+      }
+
+      // The leaf node containing middleId might have changed due to splits
+      const newLeaf = path?.[0].node;
+
+      // Either we have the same leaf (if it wasn't split) or a different one
+      if (originalLeaf === newLeaf) {
+        // If the same leaf, it should contain middleId in the same position
+        expect(originalLeaf.bunchId).to.equal("id10");
+        expect(originalLeaf.startCounter).to.equal(0);
+      } else {
+        // If a new leaf, it should still contain middleId
+        expect(newLeaf.bunchId).to.equal("id10");
+        expect(newLeaf.startCounter).to.equal(0);
+      }
+    });
+  });
+
+  describe("replaceLeaf function", () => {
+    it("should properly replace a leaf node with multiple nodes", () => {
+      let list = IdList.new();
+
+      // Create a list with sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 5);
+
+      // Get the initial root
+      // @ts-expect-error Accessing private field
+      const initialRoot = list["root"];
+
+      // Insert a value that should cause a leaf split
+      list = list.insertAfter(createId("bunch", 2), createId("split", 0));
+
+      // Get the new root
+      // @ts-expect-error Accessing private field
+      const newRoot = list["root"];
+
+      // The new root might be different if the tree height increased
+      // Test that the insertion and leaf replacement worked
+      expect(list.indexOf(createId("bunch", 0))).to.equal(0);
+      expect(list.indexOf(createId("bunch", 1))).to.equal(1);
+      expect(list.indexOf(createId("bunch", 2))).to.equal(2);
+      expect(list.indexOf(createId("split", 0))).to.equal(3);
+      expect(list.indexOf(createId("bunch", 3))).to.equal(4);
+      expect(list.indexOf(createId("bunch", 4))).to.equal(5);
+    });
+
+    it("should maintain correct sizes when replacing leaves", () => {
+      let list = IdList.new();
+
+      // Create a list with sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Insert more elements that will cause leaf splits
+      for (let i = 0; i < 5; i++) {
+        list = list.insertAfter(
+          createId("bunch", i * 2),
+          createId(`split${i}`, 0)
+        );
+      }
+
+      // @ts-expect-error Accessing private field
+      const root = list["root"];
+
+      // Helper to verify node sizes are consistent
+      function verifyNodeSizes(node) {
+        if (node.children && node.children[0].children) {
+          // Inner node with inner node children
+          let calculatedSize = 0;
+          let calculatedKnownSize = 0;
+
+          for (const child of node.children) {
+            verifyNodeSizes(child);
+            calculatedSize += child.size;
+            calculatedKnownSize += child.knownSize;
+          }
+
+          // The node's size should equal the sum of its children's sizes
+          expect(node.size).to.equal(calculatedSize);
+          expect(node.knownSize).to.equal(calculatedKnownSize);
+        } else if (node.children) {
+          // Inner node with leaf children
+          let calculatedSize = 0;
+          let calculatedKnownSize = 0;
+
+          for (const child of node.children) {
+            calculatedSize += child.present.count();
+            calculatedKnownSize += child.count;
+          }
+
+          // The node's size should equal the sum of its children's sizes
+          expect(node.size).to.equal(calculatedSize);
+          expect(node.knownSize).to.equal(calculatedKnownSize);
+        }
+      }
+
+      verifyNodeSizes(root);
+
+      // The root size should match the list length
+      expect(root.size).to.equal(list.length);
+      expect(root.knownSize).to.equal(list.knownIds.length);
+    });
+  });
+
+  describe("splitPresent function", () => {
+    it("should correctly split present values", () => {
+      let list = IdList.new();
+
+      // Create a list with sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Delete some elements to create gaps in present values
+      list = list.delete(createId("bunch", 3));
+      list = list.delete(createId("bunch", 4));
+      list = list.delete(createId("bunch", 7));
+
+      // Now cause a split by inserting in the middle
+      list = list.insertAfter(createId("bunch", 5), createId("split", 0));
+
+      // Verify the structure after split
+      for (let i = 0; i < 10; i++) {
+        if (i === 3 || i === 4 || i === 7) {
+          expect(list.has(createId("bunch", i))).to.be.false;
+          expect(list.isKnown(createId("bunch", i))).to.be.true;
+        } else {
+          expect(list.has(createId("bunch", i))).to.be.true;
+        }
+      }
+
+      expect(list.has(createId("split", 0))).to.be.true;
+
+      // The order should be preserved with the split element in the middle
+      expect(list.indexOf(createId("bunch", 2))).to.equal(2);
+      expect(list.indexOf(createId("bunch", 5))).to.equal(3);
+      expect(list.indexOf(createId("split", 0))).to.equal(4);
+      expect(list.indexOf(createId("bunch", 6))).to.equal(5);
+    });
+  });
+
+  describe("save and load with edge cases", () => {
+    it("should correctly serialize and deserialize complex tree structures", () => {
+      let list = IdList.new();
+
+      // Create a list with elements that force a multi-level tree
+      for (let i = 0; i < 50; i++) {
+        // Alternate between sequential and non-sequential IDs
+        if (i % 10 === 0) {
+          // Start a new sequence
+          list = list.insertAfter(
+            i === 0
+              ? null
+              : createId(`seq${Math.floor((i - 1) / 10)}`, (i % 10) - 1),
+            createId(`seq${Math.floor(i / 10)}`, 0)
+          );
+        } else {
+          // Continue the sequence
+          list = list.insertAfter(
+            createId(`seq${Math.floor(i / 10)}`, (i % 10) - 1),
+            createId(`seq${Math.floor(i / 10)}`, i % 10)
+          );
+        }
+      }
+
+      // Delete some elements to create gaps
+      for (let i = 0; i < 5; i++) {
+        list = list.delete(createId(`seq${i}`, 5));
+      }
+
+      // Save the state
+      const saved = list.save();
+
+      // Load the saved state
+      const loadedList = IdList.load(saved);
+
+      // Verify the loaded list matches the original
+      expect(loadedList.length).to.equal(list.length);
+
+      // Check a few elements from each sequence
+      for (let i = 0; i < 5; i++) {
+        for (let j = 0; j < 10; j++) {
+          if (j === 5) {
+            // This element was deleted
+            expect(loadedList.has(createId(`seq${i}`, j))).to.be.false;
+            expect(loadedList.isKnown(createId(`seq${i}`, j))).to.be.true;
+          } else {
+            expect(loadedList.has(createId(`seq${i}`, j))).to.be.true;
+          }
+        }
+      }
+    });
+
+    it("should correct handle serializing deleted items at end of leaf nodes", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("seq", 0), 10);
+
+      // Delete the last few elements
+      list = list.delete(createId("seq", 7));
+      list = list.delete(createId("seq", 8));
+      list = list.delete(createId("seq", 9));
+
+      // Save and load
+      const saved = list.save();
+      const loadedList = IdList.load(saved);
+
+      // Verify all deleted elements are still known
+      for (let i = 7; i < 10; i++) {
+        expect(loadedList.has(createId("seq", i))).to.be.false;
+        expect(loadedList.isKnown(createId("seq", i))).to.be.true;
+      }
+
+      // Verify the correct number of elements are present
+      expect(loadedList.length).to.equal(7);
+      expect(loadedList.knownIds.length).to.equal(10);
+    });
+  });
+
+  describe("buildTree function", () => {
+    it("should create a balanced tree from leaves", () => {
+      // Create a SavedIdList with enough entries to require multiple levels
+      const savedState = [];
+      for (let i = 0; i < 100; i++) {
+        savedState.push({
+          bunchId: `bunch${i}`,
+          startCounter: 0,
+          count: 1,
+          isDeleted: i % 5 === 0, // Make some deleted
+        });
+      }
+
+      // Load into a new IdList
+      const list = IdList.load(savedState);
+
+      // @ts-expect-error Accessing private field
+      const root = list["root"];
+
+      // Helper to check tree height and balance
+      function getTreeHeight(node) {
+        if (node.children && node.children[0].children) {
+          // Inner node with inner node children
+          const childHeights = node.children.map(getTreeHeight);
+
+          // All children should have the same height (balanced)
+          const firstHeight = childHeights[0];
+          expect(childHeights.every((h) => h === firstHeight)).to.be.true;
+
+          return 1 + firstHeight;
+        } else {
+          // Inner node with leaf children
+          return 1;
+        }
+      }
+
+      const height = getTreeHeight(root);
+
+      // For 100 elements with M=8, height should be around 3
+      expect(height).to.be.greaterThanOrEqual(2);
+      expect(height).to.be.lessThanOrEqual(4);
+
+      // Check that all elements are accessible
+      let presentCount = 0;
+      let knownCount = 0;
+
+      for (let i = 0; i < 100; i++) {
+        const id = createId(`bunch${i}`, 0);
+        expect(list.isKnown(id)).to.be.true;
+        knownCount++;
+
+        if (i % 5 !== 0) {
+          expect(list.has(id)).to.be.true;
+          presentCount++;
+        } else {
+          expect(list.has(id)).to.be.false;
+        }
+      }
+
+      expect(list.length).to.equal(presentCount);
+      expect(list.knownIds.length).to.equal(knownCount);
+    });
+  });
+
+  describe("KnownIdView", () => {
+    it("should correctly handle at() and indexOf() with deleted elements", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("seq", 0), 10);
+
+      // Delete some elements
+      list = list.delete(createId("seq", 3));
+      list = list.delete(createId("seq", 7));
+
+      const knownIds = list.knownIds;
+
+      // Check at() returns deleted elements at their position
+      expect(knownIds.at(3)).to.deep.equal(createId("seq", 3));
+      expect(knownIds.at(7)).to.deep.equal(createId("seq", 7));
+
+      // Check indexOf() works for both present and deleted
+      for (let i = 0; i < 10; i++) {
+        expect(knownIds.indexOf(createId("seq", i))).to.equal(i);
+      }
+    });
+
+    it("should maintain knownIds view across complex operations", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("seq", 0), 10);
+
+      // Get initial knownIds view
+      const knownIds1 = list.knownIds;
+
+      // Perform some operations
+      list = list.delete(createId("seq", 3));
+      list = list.insertAfter(createId("seq", 5), createId("new", 0));
+
+      // Get updated knownIds view
+      const knownIds2 = list.knownIds;
+
+      // Verify the knownIds views are correct
+      expect(knownIds1.length).to.equal(10);
+      expect(knownIds2.length).to.equal(11);
+
+      // Check the first view hasn't changed
+      for (let i = 0; i < 10; i++) {
+        expect(knownIds1.at(i)).to.deep.equal(createId("seq", i));
+      }
+
+      // Check the second view has the new element and maintains its order
+      for (let i = 0; i < 6; i++) {
+        expect(knownIds2.at(i)).to.deep.equal(createId("seq", i));
+      }
+      expect(knownIds2.at(6)).to.deep.equal(createId("new", 0));
+      for (let i = 6; i < 10; i++) {
+        expect(knownIds2.at(i + 1)).to.deep.equal(createId("seq", i));
+      }
+    });
+  });
+});

--- a/test/btree_structure_and_edge_cases.test.ts
+++ b/test/btree_structure_and_edge_cases.test.ts
@@ -242,8 +242,8 @@ describe("IdList Internal Structure", () => {
 
       // Verify the loaded list matches the original
       expect(loadedList.length).to.equal(list.length);
-      expect([...loadedList.valuesWithDeleted()]).to.deep.equal([
-        ...list.valuesWithDeleted(),
+      expect([...loadedList.valuesWithIsDeleted()]).to.deep.equal([
+        ...list.valuesWithIsDeleted(),
       ]);
     });
 

--- a/test/fuzzer.ts
+++ b/test/fuzzer.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { ElementId, IdList } from "../src";
+import { IdList as IdListSimple } from "./id_list_simple";
+
+/**
+ * Applies mutations to both IdList and IdListSimple (a simpler, known-good implementation),
+ * erroring if the resulting states differ.
+ */
+export class Fuzzer {
+  private constructor(readonly list: IdList, readonly simple: IdListSimple) {
+    // Check that states agree.
+    expect([...list.valuesWithDeleted()]).to.deep.equal([
+      ...simple.valuesWithDeleted(),
+    ]);
+  }
+
+  /**
+   * Check that all accessors agree.
+   *
+   * Not called on every mutation because it is more expensive.
+   */
+  checkAll() {
+    expect(this.list.length).to.equal(this.simple.length);
+    for (let i = 0; i < this.simple.length; i++) {
+      expect(this.list.at(i)).to.deep.equal(this.simple.at(i));
+      expect(this.list.indexOf(this.simple.at(i))).to.equal(i);
+    }
+    expect([...this.list.values()]).to.deep.equal([...this.simple.values()]);
+    expect(this.list.save()).to.deep.equal(this.simple.save());
+
+    expect(this.list.knownIds.length).to.equal(this.simple.knownIds.length);
+    for (let i = 0; i < this.simple.knownIds.length; i++) {
+      expect(this.list.knownIds.at(i)).to.deep.equal(
+        this.simple.knownIds.at(i)
+      );
+      expect(this.list.knownIds.indexOf(this.simple.knownIds.at(i))).to.equal(
+        i
+      );
+    }
+    expect([...this.list.knownIds.values()]).to.deep.equal([
+      ...this.simple.knownIds.values(),
+    ]);
+
+    // Check loaded state as well.
+    expect([
+      ...IdList.load(this.list.save()).valuesWithDeleted(),
+    ]).to.deep.equal([...this.simple.valuesWithDeleted()]);
+  }
+
+  static new() {
+    return new Fuzzer(IdList.new(), IdListSimple.new());
+  }
+
+  static from(knownIds: Iterable<{ id: ElementId; isDeleted: boolean }>) {
+    return new Fuzzer(IdList.from(knownIds), IdListSimple.from(knownIds));
+  }
+
+  static fromIds(ids: Iterable<ElementId>) {
+    return new Fuzzer(IdList.fromIds(ids), IdListSimple.fromIds(ids));
+  }
+
+  insertAfter(before: ElementId | null, newId: ElementId, count?: number) {
+    return new Fuzzer(
+      this.list.insertAfter(before, newId, count),
+      this.simple.insertAfter(before, newId, count)
+    );
+  }
+
+  insertBefore(after: ElementId | null, newId: ElementId, count?: number) {
+    return new Fuzzer(
+      this.list.insertBefore(after, newId, count),
+      this.simple.insertBefore(after, newId, count)
+    );
+  }
+
+  delete(id: ElementId) {
+    return new Fuzzer(this.list.delete(id), this.simple.delete(id));
+  }
+
+  undelete(id: ElementId) {
+    return new Fuzzer(this.list.undelete(id), this.simple.undelete(id));
+  }
+}

--- a/test/fuzzer.ts
+++ b/test/fuzzer.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ElementId, IdList } from "../src";
-import { IdList as IdListSimple } from "./id_list_simple";
+import { IdListSimple } from "./id_list_simple";
 
 const DEBUG = false;
 

--- a/test/fuzzer.ts
+++ b/test/fuzzer.ts
@@ -2,12 +2,14 @@ import { expect } from "chai";
 import { ElementId, IdList } from "../src";
 import { IdList as IdListSimple } from "./id_list_simple";
 
+const DEBUG = false;
+
 /**
  * Applies mutations to both IdList and IdListSimple (a simpler, known-good implementation),
  * erroring if the resulting states differ.
  */
 export class Fuzzer {
-  private constructor(readonly list: IdList, readonly simple: IdListSimple) {
+  constructor(readonly list: IdList, readonly simple: IdListSimple) {
     // Check that states agree.
     expect([...list.valuesWithDeleted()]).to.deep.equal([
       ...simple.valuesWithDeleted(),
@@ -60,6 +62,9 @@ export class Fuzzer {
   }
 
   insertAfter(before: ElementId | null, newId: ElementId, count?: number) {
+    if (DEBUG) {
+      console.log("insertAfter", before, newId, count);
+    }
     return new Fuzzer(
       this.list.insertAfter(before, newId, count),
       this.simple.insertAfter(before, newId, count)
@@ -67,6 +72,9 @@ export class Fuzzer {
   }
 
   insertBefore(after: ElementId | null, newId: ElementId, count?: number) {
+    if (DEBUG) {
+      console.log("insertBefore", after, newId, count);
+    }
     return new Fuzzer(
       this.list.insertBefore(after, newId, count),
       this.simple.insertBefore(after, newId, count)
@@ -74,10 +82,16 @@ export class Fuzzer {
   }
 
   delete(id: ElementId) {
+    if (DEBUG) {
+      console.log("delete", id);
+    }
     return new Fuzzer(this.list.delete(id), this.simple.delete(id));
   }
 
   undelete(id: ElementId) {
+    if (DEBUG) {
+      console.log("undelete", id);
+    }
     return new Fuzzer(this.list.undelete(id), this.simple.undelete(id));
   }
 }

--- a/test/fuzzer.ts
+++ b/test/fuzzer.ts
@@ -28,8 +28,8 @@ export class Fuzzer {
     }
 
     // Check that states agree.
-    expect([...this.list.valuesWithDeleted()]).to.deep.equal([
-      ...this.simple.valuesWithDeleted(),
+    expect([...this.list.valuesWithIsDeleted()]).to.deep.equal([
+      ...this.simple.valuesWithIsDeleted(),
     ]);
   }
 
@@ -62,8 +62,8 @@ export class Fuzzer {
 
     // Check loaded state as well.
     expect([
-      ...IdList.load(this.list.save()).valuesWithDeleted(),
-    ]).to.deep.equal([...this.simple.valuesWithDeleted()]);
+      ...IdList.load(this.list.save()).valuesWithIsDeleted(),
+    ]).to.deep.equal([...this.simple.valuesWithIsDeleted()]);
   }
 
   static new() {

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -96,8 +96,8 @@ export class IdList {
    * @throws If `newId` is already known.
    */
   insertAfter(before: ElementId | null, newId: ElementId, count = 1) {
-    if (this.isKnown(newId)) {
-      throw new Error("newId is already known");
+    if (this.isAnyKnown(newId, count)) {
+      throw new Error("An inserted id is already known");
     }
 
     let index: number;
@@ -141,8 +141,8 @@ export class IdList {
    * @throws If `newId` is already known.
    */
   insertBefore(after: ElementId | null, newId: ElementId, count = 1) {
-    if (this.isKnown(newId)) {
-      throw new Error("newId is already known");
+    if (this.isAnyKnown(newId, count)) {
+      throw new Error("An inserted id is already known");
     }
 
     let index: number;
@@ -249,7 +249,16 @@ export class IdList {
    * Compare to {@link has}.
    */
   isKnown(id: ElementId): boolean {
-    return this.state.some((elt) => equalsId(elt.id, id));
+    return this.isAnyKnown(id, 1);
+  }
+
+  private isAnyKnown(id: ElementId, count: number): boolean {
+    return this.state.some(
+      (elt) =>
+        elt.id.bunchId === id.bunchId &&
+        id.counter <= elt.id.counter &&
+        elt.id.counter < id.counter + count
+    );
   }
 
   /**

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -112,15 +112,9 @@ export class IdListSimple {
       throw new Error("An inserted id is already known");
     }
 
-    return new IdListSimple(
-      this.state
-        .slice(0, index + 1)
-        .concat(
-          expandElements(newId, false, count),
-          this.state.slice(index + 1)
-        ),
-      this.length + count
-    );
+    const newState = this.state.slice();
+    newState.splice(index + 1, 0, ...expandElements(newId, false, count));
+    return new IdListSimple(newState, this.length + count);
   }
 
   /**
@@ -156,12 +150,9 @@ export class IdListSimple {
     }
 
     // We insert the bunch from left-to-right even though it's insertBefore.
-    return new IdListSimple(
-      this.state
-        .slice(0, index)
-        .concat(expandElements(newId, false, count), this.state.slice(index)),
-      this.length + count
-    );
+    const newState = this.state.slice();
+    newState.splice(index, 0, ...expandElements(newId, false, count));
+    return new IdListSimple(newState, this.length + count);
   }
 
   /**
@@ -180,15 +171,9 @@ export class IdListSimple {
     if (index != -1) {
       const elt = this.state[index];
       if (!elt.isDeleted) {
-        return new IdListSimple(
-          this.state
-            .slice(0, index)
-            .concat(
-              [{ id: elt.id, isDeleted: true }],
-              this.state.slice(index + 1)
-            ),
-          this.length - 1
-        );
+        const newState = this.state.slice();
+        newState.splice(index, 1, { id: elt.id, isDeleted: true });
+        return new IdListSimple(newState, this.length - 1);
       }
     }
 
@@ -212,15 +197,9 @@ export class IdListSimple {
     }
     const elt = this.state[index];
     if (elt.isDeleted) {
-      return new IdListSimple(
-        this.state
-          .slice(0, index)
-          .concat(
-            [{ id: elt.id, isDeleted: false }],
-            this.state.slice(index + 1)
-          ),
-        this.length + 1
-      );
+      const newState = this.state.slice();
+      newState.splice(index, 1, { id: elt.id, isDeleted: false });
+      return new IdListSimple(newState, this.length + 1);
     }
 
     return this;

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -395,8 +395,7 @@ export class IdList {
       if (!(Number.isSafeInteger(count) && count >= 0)) {
         throw new Error(`Invalid count: ${count}`);
       }
-      // Negative counters are okay, but they must be integral.
-      if (!Number.isSafeInteger(startCounter)) {
+      if (!(Number.isSafeInteger(count) && count >= 0)) {
         throw new Error(`Invalid startCounter: ${startCounter}`);
       }
 

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -5,6 +5,8 @@ interface ListElement {
   readonly isDeleted: boolean;
 }
 
+// Simpler implementation of IdList, used for illustration purposes and fuzz testing.
+
 /**
  * A list of ElementIds, as a persistent (immutable) data structure.
  *

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -93,13 +93,9 @@ export class IdList {
    * @param count Provide this to bulk-insert `count` ids from left-to-right,
    * starting with newId and proceeding with the same bunchId and sequential counters.
    * @throws If `before` is not known.
-   * @throws If `newId` is already known.
+   * @throws If any inserted id is already known.
    */
   insertAfter(before: ElementId | null, newId: ElementId, count = 1) {
-    if (this.isAnyKnown(newId, count)) {
-      throw new Error("An inserted id is already known");
-    }
-
     let index: number;
     if (before === null) {
       // -1 so index + 1 is 0: insert at the beginning of the list.
@@ -112,6 +108,9 @@ export class IdList {
     }
 
     if (count === 0) return this;
+    if (this.isAnyKnown(newId, count)) {
+      throw new Error("An inserted id is already known");
+    }
 
     return new IdList(
       this.state
@@ -138,13 +137,9 @@ export class IdList {
    * __Note__: Although the new ids are inserted to the left of `after`, they are still
    * inserted in left-to-right order relative to each other.
    * @throws If `after` is not known.
-   * @throws If `newId` is already known.
+   * @throws If any inserted id is already known.
    */
   insertBefore(after: ElementId | null, newId: ElementId, count = 1) {
-    if (this.isAnyKnown(newId, count)) {
-      throw new Error("An inserted id is already known");
-    }
-
     let index: number;
     if (after === null) {
       index = this.state.length;
@@ -156,6 +151,9 @@ export class IdList {
     }
 
     if (count === 0) return this;
+    if (this.isAnyKnown(newId, count)) {
+      throw new Error("An inserted id is already known");
+    }
 
     // We insert the bunch from left-to-right even though it's insertBefore.
     return new IdList(

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -317,7 +317,10 @@ export class IdListSimple {
   /**
    * Iterates over all __known__ ids in the list, indicating which are deleted.
    */
-  valuesWithDeleted(): IterableIterator<{ id: ElementId; isDeleted: boolean }> {
+  valuesWithIsDeleted(): IterableIterator<{
+    id: ElementId;
+    isDeleted: boolean;
+  }> {
     return this.state.values();
   }
 
@@ -353,6 +356,7 @@ export class IdListSimple {
           id.counter === current.startCounter + current.count &&
           isDeleted === current.isDeleted
         ) {
+          // @ts-expect-error Mutating for convenience; no aliasing to worry about.
           current.count++;
           continue;
         }

--- a/test/id_list_simple.ts
+++ b/test/id_list_simple.ts
@@ -173,9 +173,6 @@ export class IdList {
    * operations, including ones sent concurrently by other devices.
    * However, it does occupy space in memory (compressed in common cases).
    *
-   * For an exact inverse to `insertAfter(-, id)` or `insertBefore(-, id)`
-   * that makes `id` no longer known, see {@link uninsert}.
-   *
    * If `id` is already deleted or not known, this method does nothing.
    */
   delete(id: ElementId) {

--- a/test/serialization_and_edge_cases.test.ts
+++ b/test/serialization_and_edge_cases.test.ts
@@ -14,8 +14,8 @@ describe("IdList Serialization and Edge Cases", () => {
     expect([...loaded.knownIds.values()]).to.deep.equal([
       ...list.knownIds.values(),
     ]);
-    expect([...loaded.valuesWithDeleted()]).to.deep.equal([
-      ...list.valuesWithDeleted(),
+    expect([...loaded.valuesWithIsDeleted()]).to.deep.equal([
+      ...list.valuesWithIsDeleted(),
     ]);
   }
 
@@ -456,8 +456,8 @@ describe("IdList Serialization and Edge Cases", () => {
       const presentIds = [...list];
       expect(presentIds.length).to.equal(7);
 
-      // Test valuesWithDeleted (all known values)
-      const allValues = [...list.valuesWithDeleted()];
+      // Test valuesWithIsDeleted (all known values)
+      const allValues = [...list.valuesWithIsDeleted()];
       expect(allValues.length).to.equal(10);
 
       // Check the deleted status for each value
@@ -519,8 +519,8 @@ describe("IdList Serialization and Edge Cases", () => {
       // Expected count: 50 original - 10 deleted + 10 new = 50
       expect(presentIds.length).to.equal(50);
 
-      // Check for deleted elements using valuesWithDeleted
-      const allValues = [...list.valuesWithDeleted()];
+      // Check for deleted elements using valuesWithIsDeleted
+      const allValues = [...list.valuesWithIsDeleted()];
       expect(allValues.length).to.equal(60); // 50 original + 10 new
 
       // Verify all new elements are present

--- a/test/serialization_and_edge_cases.test.ts
+++ b/test/serialization_and_edge_cases.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ElementId, IdList, SavedIdList } from "../src";
-import { InnerNode, InnerNodeInner, LeafNode } from "../src/id_list";
+import { InnerNode, InnerNodeInner, LeafNode, M } from "../src/id_list";
 
 describe("IdList Serialization and Edge Cases", () => {
   // Helper to create ElementIds
@@ -289,10 +289,10 @@ describe("IdList Serialization and Edge Cases", () => {
         const height = getTreeHeight(root);
 
         // Height should be approximately log_M(n), where M=8 is branching factor
-        const expectedHeight = Math.ceil(Math.log(numElements) / Math.log(8));
+        const expectedHeight = Math.ceil(Math.log(numElements) / Math.log(M));
 
         // For small trees, height might be 1 even if expected is 0
-        if (numElements > 8) {
+        if (numElements > M) {
           expect(height).to.be.closeTo(expectedHeight, 1);
         }
 

--- a/test/serialization_and_edge_cases.test.ts
+++ b/test/serialization_and_edge_cases.test.ts
@@ -130,6 +130,30 @@ describe("IdList Serialization and Edge Cases", () => {
 
       checkIterators(loaded, list);
     });
+
+    it("should handle non-merged leaves correctly", () => {
+      // See typedoc for pushSaveItem.
+
+      let list = IdList.new();
+
+      // Create un-merged leaves.
+      list = list.insertAfter(null, createId("a", 0));
+      list = list.insertAfter(createId("a", 0), createId("a", 2));
+      list = list.insertAfter(createId("a", 0), createId("a", 1));
+
+      // Verify that the leaves are not fully merged.
+      expect(list["root"].children.length).to.be.greaterThan(1);
+
+      // Verify that the resulting save item is merged.
+      const saved = list.save();
+      expect(saved.length).to.equal(1);
+
+      // Verify the loading "fixes" the un-merged leaves.
+      const loaded = IdList.load(saved);
+      expect(loaded["root"].children.length).to.equal(1);
+
+      checkIterators(loaded, list);
+    });
   });
 
   describe("load function", () => {

--- a/test/serialization_and_edge_cases.test.ts
+++ b/test/serialization_and_edge_cases.test.ts
@@ -1,0 +1,537 @@
+import { expect } from "chai";
+import { ElementId, IdList } from "../src";
+
+describe("IdList Serialization and Edge Cases", () => {
+  // Helper to create ElementIds
+  const createId = (bunchId: string, counter: number): ElementId => ({
+    bunchId,
+    counter,
+  });
+
+  describe("saveNode function", () => {
+    it("should properly serialize deleted elements at the end of leaves", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Delete the last few elements
+      list = list.delete(createId("bunch", 7));
+      list = list.delete(createId("bunch", 8));
+      list = list.delete(createId("bunch", 9));
+
+      // Save the state
+      const saved = list.save();
+
+      // Check that the saved state includes the deleted elements
+      let hasDeletedEntries = false;
+      for (const entry of saved) {
+        if (entry.bunchId === "bunch" && entry.isDeleted) {
+          hasDeletedEntries = true;
+          expect(entry.startCounter).to.equal(7);
+          expect(entry.count).to.equal(3);
+        }
+      }
+
+      expect(hasDeletedEntries).to.be.true;
+
+      // Load and verify
+      const loaded = IdList.load(saved);
+
+      // Verify deleted elements are still known
+      for (let i = 7; i < 10; i++) {
+        expect(loaded.isKnown(createId("bunch", i))).to.be.true;
+        expect(loaded.has(createId("bunch", i))).to.be.false;
+      }
+    });
+
+    it("should handle complex patterns of present and deleted elements", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 20);
+
+      // Create a complex pattern of deletions (alternating present/deleted)
+      for (let i = 1; i < 20; i += 2) {
+        list = list.delete(createId("bunch", i));
+      }
+
+      // Save the state
+      const saved = list.save();
+
+      // There should be multiple entries in the saved state
+      // Each entry represents either all present or all deleted elements
+      expect(saved.length).to.be.greaterThan(1);
+
+      // The entries should alternate between present and deleted
+      for (let i = 0; i < saved.length - 1; i++) {
+        expect(saved[i].isDeleted).to.not.equal(saved[i + 1].isDeleted);
+      }
+
+      // Load and verify
+      const loaded = IdList.load(saved);
+
+      // Check all elements
+      for (let i = 0; i < 20; i++) {
+        expect(loaded.isKnown(createId("bunch", i))).to.be.true;
+
+        if (i % 2 === 0) {
+          expect(loaded.has(createId("bunch", i))).to.be.true;
+        } else {
+          expect(loaded.has(createId("bunch", i))).to.be.false;
+        }
+      }
+    });
+
+    it("should handle interleaving bunchIds correctly", () => {
+      let list = IdList.new();
+
+      // Create an interleaved pattern of bunchIds
+      for (let i = 0; i < 10; i++) {
+        if (i === 0) {
+          list = list.insertAfter(null, createId("a", 0));
+        } else {
+          const prevId = list.at(i - 1);
+          if (i % 2 === 0) {
+            list = list.insertAfter(prevId, createId("a", i / 2));
+          } else {
+            list = list.insertAfter(prevId, createId("b", Math.floor(i / 2)));
+          }
+        }
+      }
+
+      // Save and load
+      const saved = list.save();
+      const loaded = IdList.load(saved);
+
+      // Verify the pattern is preserved
+      for (let i = 0; i < 10; i++) {
+        if (i % 2 === 0) {
+          expect(loaded.at(i)).to.deep.equal(createId("a", i / 2));
+        } else {
+          expect(loaded.at(i)).to.deep.equal(createId("b", Math.floor(i / 2)));
+        }
+      }
+    });
+  });
+
+  describe("load function", () => {
+    it("should correctly handle empty SavedIdList", () => {
+      const saved = [];
+      const list = IdList.load(saved);
+
+      expect(list.length).to.equal(0);
+    });
+
+    it("should skip entries with count = 0", () => {
+      const saved = [
+        {
+          bunchId: "bunch",
+          startCounter: 0,
+          count: 0,
+          isDeleted: false,
+        },
+        {
+          bunchId: "bunch",
+          startCounter: 1,
+          count: 5,
+          isDeleted: false,
+        },
+      ];
+
+      const list = IdList.load(saved);
+
+      // Should only have the second entry
+      expect(list.length).to.equal(5);
+      expect(list.has(createId("bunch", 0))).to.be.false;
+      expect(list.has(createId("bunch", 1))).to.be.true;
+    });
+
+    it("should throw on invalid count or startCounter", () => {
+      // Negative count
+      const saved1 = [
+        {
+          bunchId: "bunch",
+          startCounter: 0,
+          count: -1,
+          isDeleted: false,
+        },
+      ];
+      expect(() => IdList.load(saved1)).to.throw();
+
+      // Non-integer count
+      const saved2 = [
+        {
+          bunchId: "bunch",
+          startCounter: 0,
+          count: 1.5,
+          isDeleted: false,
+        },
+      ];
+      expect(() => IdList.load(saved2)).to.throw();
+
+      // Negative startCounter
+      const saved3 = [
+        {
+          bunchId: "bunch",
+          startCounter: -1,
+          count: 5,
+          isDeleted: false,
+        },
+      ];
+      expect(() => IdList.load(saved3)).to.throw();
+
+      // Non-integer startCounter
+      const saved4 = [
+        {
+          bunchId: "bunch",
+          startCounter: 0.5,
+          count: 5,
+          isDeleted: false,
+        },
+      ];
+      expect(() => IdList.load(saved4)).to.throw();
+    });
+
+    it("should merge adjacent entries with the same bunchId", () => {
+      const saved = [
+        {
+          bunchId: "bunch",
+          startCounter: 0,
+          count: 5,
+          isDeleted: false,
+        },
+        {
+          bunchId: "bunch",
+          startCounter: 5, // Continues right after the previous entry
+          count: 5,
+          isDeleted: false,
+        },
+      ];
+
+      const list = IdList.load(saved);
+
+      // Should be merged into a single leaf
+      expect(list.length).to.equal(10);
+
+      // Save again to check if it's compressed
+      const resaved = list.save();
+      expect(resaved.length).to.equal(1);
+      expect(resaved[0].count).to.equal(10);
+    });
+
+    it("should not merge entries with different bunchIds or non-sequential counters", () => {
+      const saved = [
+        {
+          bunchId: "bunch1",
+          startCounter: 0,
+          count: 5,
+          isDeleted: false,
+        },
+        {
+          bunchId: "bunch2", // Different bunchId
+          startCounter: 0,
+          count: 5,
+          isDeleted: false,
+        },
+        {
+          bunchId: "bunch1",
+          startCounter: 10, // Gap in counter sequence
+          count: 5,
+          isDeleted: false,
+        },
+      ];
+
+      const list = IdList.load(saved);
+
+      expect(list.length).to.equal(15);
+
+      // Save again to check compression
+      const resaved = list.save();
+      expect(resaved.length).to.equal(3);
+    });
+  });
+
+  describe("building balanced trees", () => {
+    it("should create appropriately balanced trees based on input size", () => {
+      function testTreeBalance(numElements) {
+        const saved = [];
+
+        // Create SavedIdList with numElements entries
+        for (let i = 0; i < numElements; i++) {
+          saved.push({
+            bunchId: `id${i}`,
+            startCounter: 0,
+            count: 1,
+            isDeleted: false,
+          });
+        }
+
+        const list = IdList.load(saved);
+
+        // @ts-expect-error Accessing private field
+        const root = list["root"];
+
+        // Helper to calculate tree height
+        function getTreeHeight(node) {
+          if (node.children && node.children[0].children) {
+            // Inner node with inner node children
+            return 1 + getTreeHeight(node.children[0]);
+          } else if (node.children) {
+            // Inner node with leaf children
+            return 1;
+          } else {
+            // Leaf node
+            return 0;
+          }
+        }
+
+        const height = getTreeHeight(root);
+
+        // Height should be approximately log_M(n), where M=8 is branching factor
+        const expectedHeight = Math.ceil(Math.log(numElements) / Math.log(8));
+
+        // For small trees, height might be 1 even if expected is 0
+        if (numElements > 8) {
+          expect(height).to.be.closeTo(expectedHeight, 1);
+        }
+
+        // Check if the tree is balanced
+        function checkNodeBalance(node) {
+          if (node.children && node.children[0].children) {
+            // All children should have the same height
+            const childHeights = node.children.map(getTreeHeight);
+            const firstHeight = childHeights[0];
+
+            for (const h of childHeights) {
+              expect(h).to.equal(firstHeight);
+            }
+
+            // Recurse into children
+            for (const child of node.children) {
+              checkNodeBalance(child);
+            }
+          }
+        }
+
+        checkNodeBalance(root);
+
+        // Verify all elements are accessible
+        for (let i = 0; i < numElements; i++) {
+          expect(list.has(createId(`id${i}`, 0))).to.be.true;
+        }
+      }
+
+      // Test various tree sizes
+      testTreeBalance(5); // Small tree
+      testTreeBalance(10); // Just over M
+      testTreeBalance(70); // Medium tree (multiple levels)
+      testTreeBalance(100); // Larger tree
+    });
+  });
+
+  describe("splitPresent function edge cases", () => {
+    it("should handle splitting with sparse present values", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Delete some elements to create gaps
+      for (let i = 0; i < 10; i += 2) {
+        list = list.delete(createId("bunch", i));
+      }
+
+      // Insert in the middle to force a split
+      list = list.insertAfter(createId("bunch", 5), createId("split", 0));
+
+      // Verify the structure after the split
+      for (let i = 0; i < 10; i++) {
+        if (i % 2 === 0) {
+          expect(list.has(createId("bunch", i))).to.be.false;
+        } else {
+          expect(list.has(createId("bunch", i))).to.be.true;
+        }
+      }
+
+      expect(list.has(createId("split", 0))).to.be.true;
+
+      // The order should be preserved
+      const presentIds = [...list];
+
+      // Should have the odd-indexed "bunch" IDs and the "split" ID
+      expect(presentIds.length).to.equal(6);
+
+      // Check positions after the split
+      expect(list.indexOf(createId("bunch", 1))).to.equal(0);
+      expect(list.indexOf(createId("bunch", 3))).to.equal(1);
+      expect(list.indexOf(createId("bunch", 5))).to.equal(2);
+      expect(list.indexOf(createId("split", 0))).to.equal(3);
+      expect(list.indexOf(createId("bunch", 7))).to.equal(4);
+      expect(list.indexOf(createId("bunch", 9))).to.equal(5);
+    });
+  });
+
+  describe("iterateNode functions", () => {
+    it("should correctly iterate through nodes with mixed present/deleted values", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 10);
+
+      // Delete some elements
+      list = list.delete(createId("bunch", 2));
+      list = list.delete(createId("bunch", 5));
+      list = list.delete(createId("bunch", 8));
+
+      // Test standard iteration (present values only)
+      const presentIds = [...list];
+      expect(presentIds.length).to.equal(7);
+
+      // Test valuesWithDeleted (all known values)
+      const allValues = [...list.valuesWithDeleted()];
+      expect(allValues.length).to.equal(10);
+
+      // Check the deleted status for each value
+      for (let i = 0; i < 10; i++) {
+        const item = allValues[i];
+        expect(item.id.bunchId).to.equal("bunch");
+        expect(item.id.counter).to.equal(i);
+
+        if (i === 2 || i === 5 || i === 8) {
+          expect(item.isDeleted).to.be.true;
+        } else {
+          expect(item.isDeleted).to.be.false;
+        }
+      }
+
+      // Test knownIds iterator
+      const knownIds = [...list.knownIds];
+      expect(knownIds.length).to.equal(10);
+      for (let i = 0; i < 10; i++) {
+        expect(knownIds[i].bunchId).to.equal("bunch");
+        expect(knownIds[i].counter).to.equal(i);
+      }
+    });
+
+    it("should handle iteration after complex operations and tree restructuring", () => {
+      let list = IdList.new();
+
+      // Insert elements that will force tree restructuring
+      for (let i = 0; i < 50; i++) {
+        if (i === 0) {
+          list = list.insertAfter(null, createId(`id${i}`, 0));
+        } else {
+          list = list.insertAfter(
+            createId(`id${i - 1}`, 0),
+            createId(`id${i}`, 0)
+          );
+        }
+      }
+
+      // Delete some elements in a pattern
+      for (let i = 0; i < 50; i += 5) {
+        list = list.delete(createId(`id${i}`, 0));
+      }
+
+      // Insert new elements in between
+      let lastIndex = 0;
+      for (let i = 0; i < 10; i++) {
+        const insertAfter = `id${lastIndex + 2}`;
+        list = list.insertAfter(
+          createId(insertAfter, 0),
+          createId(`new${i}`, 0)
+        );
+        lastIndex += 3;
+      }
+
+      // Check iteration after all operations
+      const presentIds = [...list];
+
+      // Expected count: 50 original - 10 deleted + 10 new = 50
+      expect(presentIds.length).to.equal(50);
+
+      // Check for deleted elements using valuesWithDeleted
+      const allValues = [...list.valuesWithDeleted()];
+      expect(allValues.length).to.equal(60); // 50 original + 10 new
+
+      // Verify all new elements are present
+      for (let i = 0; i < 10; i++) {
+        expect(list.has(createId(`new${i}`, 0))).to.be.true;
+      }
+
+      // Verify deletion pattern
+      for (let i = 0; i < 50; i++) {
+        if (i % 5 === 0) {
+          expect(list.has(createId(`id${i}`, 0))).to.be.false;
+          expect(list.isKnown(createId(`id${i}`, 0))).to.be.true;
+        } else {
+          expect(list.has(createId(`id${i}`, 0))).to.be.true;
+        }
+      }
+    });
+  });
+
+  describe("compression during save", () => {
+    it("should optimally compress sequential runs during save", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 100);
+
+      // Save and check compression
+      const saved = list.save();
+
+      // Should be a single entry
+      expect(saved.length).to.equal(1);
+      expect(saved[0].bunchId).to.equal("bunch");
+      expect(saved[0].startCounter).to.equal(0);
+      expect(saved[0].count).to.equal(100);
+      expect(saved[0].isDeleted).to.be.false;
+
+      // Add more sequential elements
+      list = list.insertAfter(
+        createId("bunch", 99),
+        createId("bunch", 100),
+        50
+      );
+
+      // Save and check compression
+      const saved2 = list.save();
+
+      // Should still be a single entry
+      expect(saved2.length).to.equal(1);
+      expect(saved2[0].bunchId).to.equal("bunch");
+      expect(saved2[0].startCounter).to.equal(0);
+      expect(saved2[0].count).to.equal(150);
+      expect(saved2[0].isDeleted).to.be.false;
+    });
+
+    it("should correctly compress interleaved present and deleted elements", () => {
+      let list = IdList.new();
+
+      // Insert sequential IDs
+      list = list.insertAfter(null, createId("bunch", 0), 20);
+
+      // Delete every other element
+      for (let i = 0; i < 20; i += 2) {
+        list = list.delete(createId("bunch", i));
+      }
+
+      // Save and check compression
+      const saved = list.save();
+
+      // Each pair of (deleted, present) should be an entry
+      // With optimal compression, we expect 2 entries
+      expect(saved.length).to.equal(2);
+
+      // The first entry should be all the even indices (deleted)
+      expect(saved[0].bunchId).to.equal("bunch");
+      expect(saved[0].isDeleted).to.be.true;
+
+      // The second entry should be all the odd indices (present)
+      expect(saved[1].bunchId).to.equal("bunch");
+      expect(saved[1].isDeleted).to.be.false;
+    });
+  });
+});

--- a/test/serialization_and_edge_cases.test.ts
+++ b/test/serialization_and_edge_cases.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
-import { ElementId, IdList } from "../src";
+import { ElementId, IdList, SavedIdList } from "../src";
+import { InnerNode, InnerNodeInner, LeafNode } from "../src/id_list";
 
 describe("IdList Serialization and Edge Cases", () => {
   // Helper to create ElementIds
@@ -117,7 +118,7 @@ describe("IdList Serialization and Edge Cases", () => {
 
   describe("load function", () => {
     it("should correctly handle empty SavedIdList", () => {
-      const saved = [];
+      const saved: SavedIdList = [];
       const list = IdList.load(saved);
 
       expect(list.length).to.equal(0);
@@ -254,8 +255,8 @@ describe("IdList Serialization and Edge Cases", () => {
 
   describe("building balanced trees", () => {
     it("should create appropriately balanced trees based on input size", () => {
-      function testTreeBalance(numElements) {
-        const saved = [];
+      function testTreeBalance(numElements: number) {
+        const saved: SavedIdList = [];
 
         // Create SavedIdList with numElements entries
         for (let i = 0; i < numElements; i++) {
@@ -269,15 +270,14 @@ describe("IdList Serialization and Edge Cases", () => {
 
         const list = IdList.load(saved);
 
-        // @ts-expect-error Accessing private field
         const root = list["root"];
 
         // Helper to calculate tree height
-        function getTreeHeight(node) {
-          if (node.children && node.children[0].children) {
+        function getTreeHeight(node: InnerNode | LeafNode): number {
+          if ("children" in node && "children" in node.children[0]) {
             // Inner node with inner node children
             return 1 + getTreeHeight(node.children[0]);
-          } else if (node.children) {
+          } else if ("children" in node) {
             // Inner node with leaf children
             return 1;
           } else {
@@ -297,8 +297,8 @@ describe("IdList Serialization and Edge Cases", () => {
         }
 
         // Check if the tree is balanced
-        function checkNodeBalance(node) {
-          if (node.children && node.children[0].children) {
+        function checkNodeBalance(node: InnerNode) {
+          if (node.children && "children" in node.children[0]) {
             // All children should have the same height
             const childHeights = node.children.map(getTreeHeight);
             const firstHeight = childHeights[0];
@@ -308,7 +308,7 @@ describe("IdList Serialization and Edge Cases", () => {
             }
 
             // Recurse into children
-            for (const child of node.children) {
+            for (const child of (node as InnerNodeInner).children) {
               checkNodeBalance(child);
             }
           }


### PR DESCRIPTION
For practical efficiency.

The old implementation is moved to `tests/id_list_simple.ts`, so that it can be used as a reference and as a known-good implementation for fuzz tests.