### PR TITLE
Sublinear searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,20 @@ To speed up searches, we also maintain a "bottom-up" tree that maps from each no
 
 Asymptotic runtimes are given in terms of the number of leaves `L` and the maximum "fragmentation" of a leaf `F`, which is the number of times its ElementIds alternate between deleted vs present.
 
-- insertAfter, insertBefore: `O(log^2(L) + F)`
-- delete, undelete: `O(log^2(L) + F)`
-- at: `O(log(L) + F)`
-- indexOf: `O(log^2(L) + F)`
-
-Except for `at` (which does a simple B+Tree search), the bottleneck of each method is finding the B+Tree path corresponding to an ElementId's leaf. This requires `O(log(L))` lookups in the bottom-up tree's map, each of which takes `O(log(L))` time. See the implementation of `IdList.locate`.
+- insertAfter, insertBefore: `O(log^2(L) + F)`.
+  - The bottleneck is finding the B+Tree path of the before/after ElementId. This requires `O(log(L))` lookups in the bottom-up tree's map, each of which takes `O(log(L))` time. See the implementation of `IdList.locate`.
+- delete, undelete: `O(log^2(L) + F)`.
+- indexOf: `O(log^2(L) + F)`.
+  - Bottleneck is locating the id.
+- at: `O(log(L) + F)`.
+  - Simple B+Tree search.
+- has, isKnown: `O(log(L) + F)`
+  - Part of the bottom-up tree is a sorted map with leaf keys; due to the sort, we can also use that map to look up the leaf corresponding to an ElementId, in `O(log(L))` time.
+- length: `O(1)`.
+  - Cached.
+- save: `O(S + L)`, where `S <= L * F` is the saved state's length.
+- load: `O(S * log(S))`
+  - The bottleneck is constructing the bottom-up tree: specifically, the map from each leaf to its parent's sequence number (`leafMap`). That map is itself a sorted tree, hence takes `O(L * log(L))` time to construct, and `L <= S`.
 
 If you want to get a sense of what IdList is or how to implement your own version, consider reading the source code for [IdListSimple](./test/id_list_simple.ts), which behaves identically to IdList. It is short (<300 SLOC) and direct, using an array and `Array.splice`. The downside is that IdListSimple does not compress ElementIds, and all of its operations take `O(# ids)` time. We use it as a known-good implementation in our fuzz tests.
 

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -14,14 +14,14 @@ Note: This is not a fair comparison to list/text CRDTs. The executions benchmark
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 2562
+- Sender time (ms): 2428
 - Avg update size (bytes): 147.3
-- Receiver time (ms): 2570
+- Receiver time (ms): 2564
 - Save time (ms): 14
 - Save size (bytes): 1177551
-- Load time (ms): 34
-- Save time GZIP'd (ms): 55
-- Save size GZIP'd (bytes): 65894
+- Load time (ms): 35
+- Save time GZIP'd (ms): 56
+- Save size GZIP'd (bytes): 65897
 - Load time GZIP'd (ms): 60
 - Mem used estimate (MB): 2.8
 
@@ -30,13 +30,13 @@ Updates and saved states use JSON encoding, with optional GZIP for saved states.
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates use a custom string encoding; saved states use JSON with optional GZIP.
 
-- Sender time (ms): 2202
+- Sender time (ms): 2168
 - Avg update size (bytes): 45.6
-- Receiver time (ms): 3818
+- Receiver time (ms): 3787
 - Save time (ms): 13
 - Save size (bytes): 1177551
-- Load time (ms): 27
+- Load time (ms): 30
 - Save time GZIP'd (ms): 56
-- Save size GZIP'd (bytes): 65897
-- Load time GZIP'd (ms): 58
+- Save size GZIP'd (bytes): 65893
+- Load time GZIP'd (ms): 59
 - Mem used estimate (MB): 2.8

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -14,29 +14,29 @@ Note: This is not a fair comparison to list/text CRDTs. The executions benchmark
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 16371
+- Sender time (ms): 9044
 - Avg update size (bytes): 147.3
-- Receiver time (ms): 29379
-- Save time (ms): 13
+- Receiver time (ms): 8610
+- Save time (ms): 11
 - Save size (bytes): 1177551
-- Load time (ms): 22
-- Save time GZIP'd (ms): 56
-- Save size GZIP'd (bytes): 65895
-- Load time GZIP'd (ms): 49
-- Mem used estimate (MB): 2.7
+- Load time (ms): 34
+- Save time GZIP'd (ms): 57
+- Save size GZIP'd (bytes): 65894
+- Load time GZIP'd (ms): 58
+- Mem used estimate (MB): 2.8
 
 ## Insert-After, Custom Encoding
 
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates use a custom string encoding; saved states use JSON with optional GZIP.
 
-- Sender time (ms): 16080
+- Sender time (ms): 8306
 - Avg update size (bytes): 45.6
-- Receiver time (ms): 69186
-- Save time (ms): 10
+- Receiver time (ms): 12066
+- Save time (ms): 13
 - Save size (bytes): 1177551
-- Load time (ms): 20
-- Save time GZIP'd (ms): 57
-- Save size GZIP'd (bytes): 65910
-- Load time GZIP'd (ms): 51
-- Mem used estimate (MB): 2.7
+- Load time (ms): 30
+- Save time GZIP'd (ms): 55
+- Save size GZIP'd (bytes): 65905
+- Load time GZIP'd (ms): 63
+- Mem used estimate (MB): 2.8

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -14,29 +14,29 @@ Note: This is not a fair comparison to list/text CRDTs. The executions benchmark
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 31970
+- Sender time (ms): 16371
 - Avg update size (bytes): 147.3
-- Receiver time (ms): 46241
+- Receiver time (ms): 29379
 - Save time (ms): 13
 - Save size (bytes): 1177551
-- Load time (ms): 10
-- Save time GZIP'd (ms): 57
-- Save size GZIP'd (bytes): 65903
-- Load time GZIP'd (ms): 34
-- Mem used estimate (MB): 2.0
+- Load time (ms): 22
+- Save time GZIP'd (ms): 56
+- Save size GZIP'd (bytes): 65895
+- Load time GZIP'd (ms): 49
+- Mem used estimate (MB): 2.7
 
 ## Insert-After, Custom Encoding
 
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates use a custom string encoding; saved states use JSON with optional GZIP.
 
-- Sender time (ms): 36108
+- Sender time (ms): 16080
 - Avg update size (bytes): 45.6
-- Receiver time (ms): 111874
-- Save time (ms): 9
+- Receiver time (ms): 69186
+- Save time (ms): 10
 - Save size (bytes): 1177551
-- Load time (ms): 6
+- Load time (ms): 20
 - Save time GZIP'd (ms): 57
-- Save size GZIP'd (bytes): 65885
-- Load time GZIP'd (ms): 36
-- Mem used estimate (MB): 2.0
+- Save size GZIP'd (bytes): 65910
+- Load time GZIP'd (ms): 51
+- Mem used estimate (MB): 2.7

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -14,15 +14,15 @@ Note: This is not a fair comparison to list/text CRDTs. The executions benchmark
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 9044
+- Sender time (ms): 2562
 - Avg update size (bytes): 147.3
-- Receiver time (ms): 8610
-- Save time (ms): 11
+- Receiver time (ms): 2570
+- Save time (ms): 14
 - Save size (bytes): 1177551
 - Load time (ms): 34
-- Save time GZIP'd (ms): 57
+- Save time GZIP'd (ms): 55
 - Save size GZIP'd (bytes): 65894
-- Load time GZIP'd (ms): 58
+- Load time GZIP'd (ms): 60
 - Mem used estimate (MB): 2.8
 
 ## Insert-After, Custom Encoding
@@ -30,13 +30,13 @@ Updates and saved states use JSON encoding, with optional GZIP for saved states.
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates use a custom string encoding; saved states use JSON with optional GZIP.
 
-- Sender time (ms): 8306
+- Sender time (ms): 2202
 - Avg update size (bytes): 45.6
-- Receiver time (ms): 12066
+- Receiver time (ms): 3818
 - Save time (ms): 13
 - Save size (bytes): 1177551
-- Load time (ms): 30
-- Save time GZIP'd (ms): 55
-- Save size GZIP'd (bytes): 65905
-- Load time GZIP'd (ms): 63
+- Load time (ms): 27
+- Save time GZIP'd (ms): 56
+- Save size GZIP'd (bytes): 65897
+- Load time GZIP'd (ms): 58
 - Mem used estimate (MB): 2.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@types/functional-red-black-tree": "^1.0.6",
+        "functional-red-black-tree": "^1.0.1",
         "sparse-array-rled": "^2.0.1"
       },
       "devDependencies": {
@@ -892,6 +894,11 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
       "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
+    },
+    "node_modules/@types/functional-red-black-tree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/functional-red-black-tree/-/functional-red-black-tree-1.0.6.tgz",
+      "integrity": "sha512-h7W9Mjozzx+HA9L7CSKAm3dSCa9vBea2U5kWfDuXedAjOb/Sy7VXWL4qUi7H03IJvwHEJ/vf2P2agw9XNTWZxg=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2669,6 +2676,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -6528,6 +6540,11 @@
       "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
+    "@types/functional-red-black-tree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/functional-red-black-tree/-/functional-red-black-tree-1.0.6.tgz",
+      "integrity": "sha512-h7W9Mjozzx+HA9L7CSKAm3dSCa9vBea2U5kWfDuXedAjOb/Sy7VXWL4qUi7H03IJvwHEJ/vf2P2agw9XNTWZxg=="
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7800,6 +7817,11 @@
         "es-abstract": "^1.22.1",
         "functions-have-names": "^1.2.3"
       }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
     },
     "functions-have-names": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@types/functional-red-black-tree": "^1.0.6",
         "functional-red-black-tree": "^1.0.1",
         "sparse-array-rled": "^2.0.1"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.4",
+        "@types/functional-red-black-tree": "^1.0.6",
         "@types/mocha": "^10.0.1",
         "@types/seedrandom": "^3.0.8",
         "@typescript-eslint/eslint-plugin": "^7.7.1",
@@ -898,7 +898,8 @@
     "node_modules/@types/functional-red-black-tree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/functional-red-black-tree/-/functional-red-black-tree-1.0.6.tgz",
-      "integrity": "sha512-h7W9Mjozzx+HA9L7CSKAm3dSCa9vBea2U5kWfDuXedAjOb/Sy7VXWL4qUi7H03IJvwHEJ/vf2P2agw9XNTWZxg=="
+      "integrity": "sha512-h7W9Mjozzx+HA9L7CSKAm3dSCa9vBea2U5kWfDuXedAjOb/Sy7VXWL4qUi7H03IJvwHEJ/vf2P2agw9XNTWZxg==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -6543,7 +6544,8 @@
     "@types/functional-red-black-tree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/functional-red-black-tree/-/functional-red-black-tree-1.0.6.tgz",
-      "integrity": "sha512-h7W9Mjozzx+HA9L7CSKAm3dSCa9vBea2U5kWfDuXedAjOb/Sy7VXWL4qUi7H03IJvwHEJ/vf2P2agw9XNTWZxg=="
+      "integrity": "sha512-h7W9Mjozzx+HA9L7CSKAm3dSCa9vBea2U5kWfDuXedAjOb/Sy7VXWL4qUi7H03IJvwHEJ/vf2P2agw9XNTWZxg==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,14 @@
     "access": "public"
   },
   "sideEffects": false,
+  "dependencies": {
+    "functional-red-black-tree": "^1.0.1",
+    "sparse-array-rled": "^2.0.1"
+  },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.4",
+    "@types/functional-red-black-tree": "^1.0.6",
     "@types/mocha": "^10.0.1",
     "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
@@ -71,10 +76,5 @@
     "benchmarks": "TS_NODE_PROJECT='./tsconfig.dev.json' node -r ts-node/register --expose-gc benchmarks/main.ts",
     "inspect": "TS_NODE_PROJECT='./tsconfig.dev.json' node -r ts-node/register --expose-gc --inspect benchmarks/main.ts",
     "clean": "rm -rf build docs coverage .nyc_output"
-  },
-  "dependencies": {
-    "@types/functional-red-black-tree": "^1.0.6",
-    "functional-red-black-tree": "^1.0.1",
-    "sparse-array-rled": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "clean": "rm -rf build docs coverage .nyc_output"
   },
   "dependencies": {
+    "@types/functional-red-black-tree": "^1.0.6",
+    "functional-red-black-tree": "^1.0.1",
     "sparse-array-rled": "^2.0.1"
   }
 }

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -504,6 +504,10 @@ export class IdList {
   private replaceLeaf(located: Located, ...newLeaves: LeafNode[]): IdList {
     const leafMapMut = { value: this.leafMap };
     const parentSeqsMut = { value: this.parentSeqs };
+
+    // Delete the replaced leaf, in case it's not replaced with a leaf having the same startCounter.
+    leafMapMut.value = leafMapMut.value.delete(located[0].node);
+
     const newRoot = replaceNode(
       located,
       this.root,

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -30,6 +30,13 @@ import { SavedIdList } from "./saved_id_list";
  and its knownSize (# of known ids). These allow indexed access in log time.
 
  Unlike some B+Trees, we do not store a linked list of leaves. Iteration instead uses a depth-first search.
+
+ Finally, we also store a "bottom-up" view of the B+Tree, in order to quickly find the leaf or
+ tree path corresponding to an ElementId. Each inner node is assigned a unique sequence number
+ (seq), and we store a persistent map from each leaf to its parent's seq (leafMap)
+ and from each inner node's seq to its parent's seq (parentSeqs). Because leafMap is sorted
+ by (LeafNode.bunchId, LeafNode.startCounter), we also use it to lookup the leaf corresponding
+ to an ElementId.
 */
 
 export interface LeafNode {

--- a/src/internal/leaf_map.ts
+++ b/src/internal/leaf_map.ts
@@ -2,7 +2,7 @@ import createRBTree, { Tree } from "functional-red-black-tree";
 import type { LeafNode } from "../id_list";
 
 /**
- * A persistent sorted map from each LeafNode to its parent's seqNum.
+ * A persistent sorted map from each LeafNode to its parent's seq.
  *
  * Leaves are sorted by their first ElementId.
  * This lets you quickly look up the LeafNode containing an ElementId,

--- a/src/internal/leaf_map.ts
+++ b/src/internal/leaf_map.ts
@@ -15,18 +15,18 @@ export class LeafMap {
     return new this(createRBTree(compareLeaves));
   }
 
-  getSeq(leaf: LeafNode): number {
-    return this.tree.get(leaf)!;
-  }
-
   /**
    * Returns the greatest leaf whose first id is <= the given id,
-   * or undefined if none exists.
+   * or undefined if none exists. Also returns the associated seq (or -1 if not found).
    *
    * The returned leaf might not actually contain the given id.
    */
-  getLeaf(bunchId: string, counter: number): LeafNode | undefined {
-    return this.tree.le({ bunchId, startCounter: counter } as LeafNode).key;
+  getLeaf(
+    bunchId: string,
+    counter: number
+  ): [leaf: LeafNode | undefined, seq: number] {
+    const iter = this.tree.le({ bunchId, startCounter: counter } as LeafNode);
+    return [iter.key, iter.value ?? -1];
   }
 
   set(leaf: LeafNode, seq: number): LeafMap {

--- a/src/internal/leaf_map.ts
+++ b/src/internal/leaf_map.ts
@@ -2,9 +2,9 @@ import createRBTree, { Tree } from "functional-red-black-tree";
 import type { LeafNode } from "../id_list";
 
 /**
- * A persistent sorted map from each LeafNodes its parent's seqNum.
+ * A persistent sorted map from each LeafNode to its parent's seqNum.
  *
- * Leaves sorted by their first ElementId.
+ * Leaves are sorted by their first ElementId.
  * This lets you quickly look up the LeafNode containing an ElementId,
  * even though the LeafNode might start at a lower counter.
  */

--- a/src/internal/leaf_map.ts
+++ b/src/internal/leaf_map.ts
@@ -1,0 +1,59 @@
+import createRBTree, { Tree } from "functional-red-black-tree";
+import type { LeafNode } from "../id_list";
+
+/**
+ * A persistent sorted map from each LeafNodes its parent's seqNum.
+ *
+ * Leaves sorted by their first ElementId.
+ * This lets you quickly look up the LeafNode containing an ElementId,
+ * even though the LeafNode might start at a lower counter.
+ */
+export class LeafMap {
+  private constructor(private readonly tree: Tree<LeafNode, number>) {}
+
+  static new() {
+    return new this(createRBTree(compareLeaves));
+  }
+
+  getSeq(leaf: LeafNode): number {
+    return this.tree.get(leaf)!;
+  }
+
+  /**
+   * Returns the greatest leaf whose first id is <= the given id,
+   * or undefined if none exists.
+   *
+   * The returned leaf might not actually contain the given id.
+   */
+  getLeaf(bunchId: string, counter: number): LeafNode | undefined {
+    return this.tree.le({ bunchId, startCounter: counter } as LeafNode).key;
+  }
+
+  set(leaf: LeafNode, seq: number): LeafMap {
+    // TODO: Vendor functional-red-black-tree and add our own set method
+    // so we can avoid this 2x penalty.
+    return new LeafMap(this.tree.remove(leaf).insert(leaf, seq));
+  }
+
+  delete(leaf: LeafNode): LeafMap {
+    return new LeafMap(this.tree.remove(leaf));
+  }
+}
+
+/**
+ * Sort function for LeafNodes in LeafMap.
+ *
+ * Sorting by startCounters lets us quickly look up the LeafNode containing an ElementId,
+ * even though the LeafNode might start at a lower counter.
+ */
+function compareLeaves(a: LeafNode, b: LeafNode) {
+  if (a.bunchId === b.bunchId) {
+    return a.startCounter - b.startCounter;
+  } else {
+    return a.bunchId > b.bunchId ? 1 : -1;
+  }
+}
+
+export interface MutableLeafMap {
+  value: LeafMap;
+}

--- a/src/internal/seq_map.ts
+++ b/src/internal/seq_map.ts
@@ -19,16 +19,18 @@ export class SeqMap {
     );
   }
 
+  bumpNextSeq(): SeqMap {
+    return new SeqMap(this.tree, this.nextSeq + 1);
+  }
+
   get(seq: number): number {
     return this.tree.get(seq)!;
   }
 
   set(seq: number, value: number): SeqMap {
-    if (seq === this.nextSeq) {
-      return new SeqMap(this.tree.insert(seq, value), this.nextSeq + 1);
-    } else {
-      return new SeqMap(this.tree.remove(seq).insert(seq, value), this.nextSeq);
-    }
+    // TODO: Vendor functional-red-black-tree and add our own set method
+    // so we can avoid this 2x penalty.
+    return new SeqMap(this.tree.remove(seq).insert(seq, value), this.nextSeq);
   }
 
   delete(seq: number): SeqMap {
@@ -38,4 +40,10 @@ export class SeqMap {
 
 export interface MutableSeqMap {
   value: SeqMap;
+}
+
+export function getAndBumpNextSeq(seqsMut: MutableSeqMap): number {
+  const nextSeq = seqsMut.value.nextSeq;
+  seqsMut.value = seqsMut.value.bumpNextSeq();
+  return nextSeq;
 }

--- a/src/internal/seq_map.ts
+++ b/src/internal/seq_map.ts
@@ -33,9 +33,9 @@ export class SeqMap {
     return new SeqMap(this.tree.remove(seq).insert(seq, value), this.nextSeq);
   }
 
-  delete(seq: number): SeqMap {
-    return new SeqMap(this.tree.remove(seq), this.nextSeq);
-  }
+  // delete(seq: number): SeqMap {
+  //   return new SeqMap(this.tree.remove(seq), this.nextSeq);
+  // }
 }
 
 export interface MutableSeqMap {

--- a/src/internal/seq_map.ts
+++ b/src/internal/seq_map.ts
@@ -1,0 +1,36 @@
+import createRBTree, { Tree } from "functional-red-black-tree";
+
+/**
+ * A persistent map from sequence numbers to values.
+ *
+ * Sequence numbers start at 1 and increment each time you call set(nextSeq, ...).
+ */
+export class SeqMap<T> {
+  constructor(
+    private readonly tree: Tree<number, T>,
+    readonly nextSeq: number
+  ) {}
+
+  static new<T>(): SeqMap<T> {
+    return new this(
+      createRBTree((a, b) => a - b),
+      0
+    );
+  }
+
+  get(seq: number): T {
+    return this.tree.get(seq)!;
+  }
+
+  set(seq: number, value: T): SeqMap<T> {
+    if (seq === this.nextSeq) {
+      return new SeqMap(this.tree.insert(seq, value), this.nextSeq + 1);
+    } else {
+      return new SeqMap(this.tree.remove(seq).insert(seq, value), this.nextSeq);
+    }
+  }
+
+  delete(seq: number): SeqMap<T> {
+    return new SeqMap(this.tree.remove(seq), this.nextSeq);
+  }
+}

--- a/src/internal/seq_map.ts
+++ b/src/internal/seq_map.ts
@@ -1,7 +1,7 @@
 import createRBTree, { Tree } from "functional-red-black-tree";
 
 /**
- * A persistent map from an InnerNode's seqNum to its parent's seqNum
+ * A persistent map from an InnerNode's seq to its parent's seq
  * (or 0 for the root).
  *
  * Sequence numbers start at 1 and increment each time you call set(nextSeq, ...).
@@ -9,7 +9,7 @@ import createRBTree, { Tree } from "functional-red-black-tree";
 export class SeqMap {
   constructor(
     private readonly tree: Tree<number, number>,
-    readonly nextSeq: number
+    private readonly nextSeq: number
   ) {}
 
   static new(): SeqMap {
@@ -43,6 +43,7 @@ export interface MutableSeqMap {
 }
 
 export function getAndBumpNextSeq(seqsMut: MutableSeqMap): number {
+  // @ts-expect-error Ignore private
   const nextSeq = seqsMut.value.nextSeq;
   seqsMut.value = seqsMut.value.bumpNextSeq();
   return nextSeq;

--- a/src/internal/seq_map.ts
+++ b/src/internal/seq_map.ts
@@ -15,7 +15,7 @@ export class SeqMap {
   static new(): SeqMap {
     return new this(
       createRBTree((a, b) => a - b),
-      0
+      1
     );
   }
 

--- a/src/internal/seq_map.ts
+++ b/src/internal/seq_map.ts
@@ -1,28 +1,29 @@
 import createRBTree, { Tree } from "functional-red-black-tree";
 
 /**
- * A persistent map from sequence numbers to values.
+ * A persistent map from an InnerNode's seqNum to its parent's seqNum
+ * (or 0 for the root).
  *
  * Sequence numbers start at 1 and increment each time you call set(nextSeq, ...).
  */
-export class SeqMap<T> {
+export class SeqMap {
   constructor(
-    private readonly tree: Tree<number, T>,
+    private readonly tree: Tree<number, number>,
     readonly nextSeq: number
   ) {}
 
-  static new<T>(): SeqMap<T> {
+  static new(): SeqMap {
     return new this(
       createRBTree((a, b) => a - b),
       0
     );
   }
 
-  get(seq: number): T {
+  get(seq: number): number {
     return this.tree.get(seq)!;
   }
 
-  set(seq: number, value: T): SeqMap<T> {
+  set(seq: number, value: number): SeqMap {
     if (seq === this.nextSeq) {
       return new SeqMap(this.tree.insert(seq, value), this.nextSeq + 1);
     } else {
@@ -30,7 +31,11 @@ export class SeqMap<T> {
     }
   }
 
-  delete(seq: number): SeqMap<T> {
+  delete(seq: number): SeqMap {
     return new SeqMap(this.tree.remove(seq), this.nextSeq);
   }
+}
+
+export interface MutableSeqMap {
+  value: SeqMap;
 }

--- a/test/btree_structure_and_edge_cases.test.ts
+++ b/test/btree_structure_and_edge_cases.test.ts
@@ -5,7 +5,6 @@ import {
   InnerNodeInner,
   InnerNodeLeaf,
   LeafNode,
-  locate,
 } from "../src/id_list";
 
 describe("IdList Internal Structure", () => {
@@ -27,12 +26,9 @@ describe("IdList Internal Structure", () => {
         list = list.insertAfter(i === 0 ? null : ids[i - 1], id);
       }
 
-      // Access internal locate function
-      const root = list["root"];
-
       // Verify locate works for all elements
       for (let i = 0; i < 50; i++) {
-        const path = locate(ids[i], root);
+        const path = list["locate"](ids[i]);
         expect(path).to.not.be.null;
         // Although a balanced BTree would have root-exclusive depth 2
         // (ceil(log_8(50))), building a tree by insert (instead of load)
@@ -47,7 +43,7 @@ describe("IdList Internal Structure", () => {
 
       // Test locate on an unknown element
       const unknownId = createId("unknown", 0);
-      const unknownPath = locate(unknownId, root);
+      const unknownPath = list["locate"](unknownId);
       expect(unknownPath).to.be.null;
     });
 
@@ -61,8 +57,7 @@ describe("IdList Internal Structure", () => {
 
       // Find the path to an element in the middle
       const middleId = createId("id10", 0);
-      let root = list["root"];
-      let path = locate(middleId, root);
+      let path = list["locate"](middleId);
 
       // Remember the leaf node that contains middleId
       const originalLeaf = path?.[0].node;
@@ -72,8 +67,7 @@ describe("IdList Internal Structure", () => {
         list = list.insertAfter(middleId, createId(`split${i}`, 0));
 
         // After each insertion, re-check the path
-        root = list["root"];
-        path = locate(middleId, root);
+        path = list["locate"](middleId);
 
         // The element should still be locatable
         expect(path).to.not.be.null;


### PR DESCRIPTION
Instead of doing a linear-time search of the whole B+Tree is has/isKnown/locate, use additional balanced trees to do log or log^2 time searches.

- [x] Balanced tree to look up individual leaves.
- [x] Balanced tree mapping nodes to their parent. This should allow locate calls (w/ full path) in `log^2(L)` time.
- [x] Update internal docs (description; asymptotic perf claims)

We need to watch memory usage. Starting: 2.0 MB (confirmed by profiling).