### PR TITLE
Cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To enable easy and efficient rollbacks, such as in a [server reconciliation](htt
 
 A **cursor** points to a gap between two list elements - e.g., a cursor in a text document.
 
-Internally, a cursor is represented as the ElementId on the left side of the gap, or null if it is at the start of the list (cursor index 0). The cursor's index changes as the id's index changes, and it also "shifts left" if that id becomes deleted. (To bind to the id on the right instead, pass `bind = "right"` to the cursor methods.)
+Internally, a cursor is represented as the ElementId on the left side of the gap, or null if it is at the start of the list. The cursor's index changes as the id's index changes, and it also "shifts left" if that id becomes deleted. (To bind to the id on the right instead, pass `bind = "right"` to the cursor methods.)
 
 Convert indices to cursors and back using the methods `cursorAt` and `cursorIndex`. These are wrappers around `at` and `indexOf` that get the edge cases correct.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ To enable easy and efficient rollbacks, such as in a [server reconciliation](htt
 - `at(index)`: Get the ElementId at a specific index.
 - `indexOf(id, bias: "none" | "left" | "right" = "none")`: Get the index of an ElementId, with optional bias for deleted-but-known ElementIds.
 
+#### Cursors
+
+A **cursor** points to a gap between two list elements - e.g., a cursor in a text document.
+
+Internally, a cursor is represented as the ElementId on the left side of the gap, or null if it is at the start of the list (cursor index 0). The cursor's index changes as the id's index changes, and it also "shifts left" if that id becomes deleted. (To bind to the id on the right instead, pass `bind = "right"` to the cursor methods.)
+
+Convert indices to cursors and back using the methods `cursorAt` and `cursorIndex`. These are wrappers around `at` and `indexOf` that get the edge cases correct.
+
 #### Bulk Operations
 
 ```typescript

--- a/src/id_list.ts
+++ b/src/id_list.ts
@@ -911,6 +911,44 @@ export class IdList {
     }
   }
 
+  /**
+   * Returns the cursor at the given index within the list, i.e., between `index - 1` and `index`.
+   * See [Cursors](https://github.com/mweidner037/articulated#cursors).
+   *
+   * Invert with {@link cursorIndex}.
+   *
+   * @param bind Whether to bind to the left or the right side of the gap, in case ids
+   * later appear between `index - 1` and `index`. Default: `"left"`, which is typical for text cursors.
+   * @throws If index is not in the range `[0, list.length]`.
+   */
+  cursorAt(index: number, bind: "left" | "right" = "left"): ElementId | null {
+    if (bind === "left") {
+      return index === 0 ? null : this.at(index - 1);
+    } else {
+      return index === this.length ? null : this.at(index);
+    }
+  }
+
+  /**
+   * Returns the current index of the given cursor within the list.
+   * That is, the cursor is in the gap between `index - 1` and `index`.
+   *
+   * Inverts {@link cursorAt}.
+   *
+   * @param bind The `bind` value that was used with {@link cursorAt}, if any.
+   * @throws If `cursor` is an ElementId that is not known.
+   */
+  cursorIndex(
+    cursor: ElementId | null,
+    bind: "left" | "right" = "left"
+  ): number {
+    if (bind === "left") {
+      return cursor === null ? 0 : this.indexOf(cursor, "left") + 1;
+    } else {
+      return cursor === null ? this.length : this.indexOf(cursor, "right");
+    }
+  }
+
   // Iterators and views
 
   /**


### PR DESCRIPTION
These are already possible with `at` and `indexOf`, but it's convenient to get the edge cases right once for everyone.