### PR TITLE
refactor: use `ElementIdGenerator` for id generation in benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
 
       - run: npm ci
-
       - run: npm test
+      - run: npm run build
+      - run: npm run benchmarks

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -14,15 +14,15 @@ Note: This is not a fair comparison to list/text CRDTs. The executions benchmark
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 2229
+- Sender time (ms): 1440
 - Avg update size (bytes): 147.3
-- Receiver time (ms): 2214
-- Save time (ms): 14
+- Receiver time (ms): 1545
+- Save time (ms): 8
 - Save size (bytes): 1177551
-- Load time (ms): 28
-- Save time GZIP'd (ms): 83
-- Save size GZIP'd (bytes): 65897
-- Load time GZIP'd (ms): 53
+- Load time (ms): 14
+- Save time GZIP'd (ms): 43
+- Save size GZIP'd (bytes): 65895
+- Load time GZIP'd (ms): 27
 - Mem used estimate (MB): 2.7
 
 ## Insert-After, Custom Encoding
@@ -30,13 +30,13 @@ Updates and saved states use JSON encoding, with optional GZIP for saved states.
 Send insertAfter and delete operations over a reliable link (e.g. WebSocket) - ElementId only.
 Updates use a custom string encoding; saved states use JSON with optional GZIP.
 
-- Sender time (ms): 1943
+- Sender time (ms): 1201
 - Avg update size (bytes): 45.6
-- Receiver time (ms): 3237
-- Save time (ms): 13
+- Receiver time (ms): 2548
+- Save time (ms): 7
 - Save size (bytes): 1177551
-- Load time (ms): 19
-- Save time GZIP'd (ms): 57
-- Save size GZIP'd (bytes): 65889
-- Load time GZIP'd (ms): 49
+- Load time (ms): 15
+- Save time GZIP'd (ms): 41
+- Save size GZIP'd (bytes): 65895
+- Load time GZIP'd (ms): 26
 - Mem used estimate (MB): 2.7

--- a/benchmarks/insert_after_custom.ts
+++ b/benchmarks/insert_after_custom.ts
@@ -23,7 +23,16 @@ export async function insertAfterCustom() {
     "Updates use a custom string encoding; saved states use JSON with optional GZIP.\n"
   );
 
-  const idGenerator = new ElementIdGenerator(() => uuidv4());
+  // TODO: Deterministic randomness.
+  const replicaId = uuidv4();
+  let replicaCounter = 0;
+  function nextBunchId(): string {
+    // This is unrealistic (more than one replica will edit a document this large)
+    // but the closest comparison to existing CRDT / list-positions benchmarks.
+    return replicaId + replicaCounter++;
+  }
+
+  const idGenerator = new ElementIdGenerator(nextBunchId);
 
   // Perform the whole trace, sending all updates.
   const updates: string[] = [];

--- a/benchmarks/insert_after_custom.ts
+++ b/benchmarks/insert_after_custom.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { v4 as uuidv4 } from "uuid";
-import { ElementId, IdList, SavedIdList } from "../src";
+import { ElementId, ElementIdGenerator, IdList, SavedIdList } from "../src";
 import {
   avg,
   getMemUsed,
@@ -10,7 +10,7 @@ import {
   sleep,
 } from "./internal/util";
 
-const { edits, finalText } = realTextTraceEdits();
+const { edits } = realTextTraceEdits();
 
 type Update = string;
 
@@ -23,14 +23,7 @@ export async function insertAfterCustom() {
     "Updates use a custom string encoding; saved states use JSON with optional GZIP.\n"
   );
 
-  // TODO: Deterministic randomness.
-  const replicaId = uuidv4();
-  let replicaCounter = 0;
-  function nextBunchId(): string {
-    // This is unrealistic (more than one replica will edit a document this large)
-    // but the closest comparison to existing CRDT / list-positions benchmarks.
-    return replicaId + replicaCounter++;
-  }
+  const idGenerator = new ElementIdGenerator(() => uuidv4());
 
   // Perform the whole trace, sending all updates.
   const updates: string[] = [];
@@ -40,17 +33,7 @@ export async function insertAfterCustom() {
     let update: Update;
     if (edit[2] !== undefined) {
       const before = edit[0] === 0 ? null : sender.at(edit[0] - 1);
-      let id: ElementId;
-      // Try to extend before's bunch, so that it will be compressed.
-      if (
-        before !== null &&
-        sender.maxCounter(before.bunchId) === before.counter
-      ) {
-        id = { bunchId: before.bunchId, counter: before.counter + 1 };
-      } else {
-        // id = { bunchId: uuidv4(), counter: 0 };
-        id = { bunchId: nextBunchId(), counter: 0 };
-      }
+      const id = idGenerator.generateAfter(before);
 
       sender = sender.insertAfter(before, id);
 

--- a/benchmarks/insert_after_json.ts
+++ b/benchmarks/insert_after_json.ts
@@ -14,10 +14,10 @@ const { edits } = realTextTraceEdits();
 
 type Update =
   | {
-    type: "insertAfter";
-    id: ElementId;
-    before: ElementId | null;
-  }
+      type: "insertAfter";
+      id: ElementId;
+      before: ElementId | null;
+    }
   | { type: "delete"; id: ElementId };
 
 export async function insertAfterJson() {

--- a/benchmarks/insert_after_json.ts
+++ b/benchmarks/insert_after_json.ts
@@ -14,10 +14,10 @@ const { edits } = realTextTraceEdits();
 
 type Update =
   | {
-      type: "insertAfter";
-      id: ElementId;
-      before: ElementId | null;
-    }
+    type: "insertAfter";
+    id: ElementId;
+    before: ElementId | null;
+  }
   | { type: "delete"; id: ElementId };
 
 export async function insertAfterJson() {
@@ -29,7 +29,16 @@ export async function insertAfterJson() {
     "Updates and saved states use JSON encoding, with optional GZIP for saved states.\n"
   );
 
-  const idGenerator = new ElementIdGenerator(() => uuidv4());
+  // TODO: Deterministic randomness.
+  const replicaId = uuidv4();
+  let replicaCounter = 0;
+  function nextBunchId(): string {
+    // This is unrealistic (more than one replica will edit a document this large)
+    // but the closest comparison to existing CRDT / list-positions benchmarks.
+    return replicaId + replicaCounter++;
+  }
+
+  const idGenerator = new ElementIdGenerator(nextBunchId);
 
   // Perform the whole trace, sending all updates.
   const updates: string[] = [];

--- a/benchmarks/insert_after_json.ts
+++ b/benchmarks/insert_after_json.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { v4 as uuidv4 } from "uuid";
-import { ElementId, IdList, SavedIdList } from "../src";
+import { ElementId, ElementIdGenerator, IdList, SavedIdList } from "../src";
 import {
   avg,
   getMemUsed,
@@ -10,7 +10,7 @@ import {
   sleep,
 } from "./internal/util";
 
-const { edits, finalText } = realTextTraceEdits();
+const { edits } = realTextTraceEdits();
 
 type Update =
   | {
@@ -29,14 +29,7 @@ export async function insertAfterJson() {
     "Updates and saved states use JSON encoding, with optional GZIP for saved states.\n"
   );
 
-  // TODO: Deterministic randomness.
-  const replicaId = uuidv4();
-  let replicaCounter = 0;
-  function nextBunchId(): string {
-    // This is unrealistic (more than one replica will edit a document this large)
-    // but the closest comparison to existing CRDT / list-positions benchmarks.
-    return replicaId + replicaCounter++;
-  }
+  const idGenerator = new ElementIdGenerator(() => uuidv4());
 
   // Perform the whole trace, sending all updates.
   const updates: string[] = [];
@@ -46,17 +39,7 @@ export async function insertAfterJson() {
     let updateObj: Update;
     if (edit[2] !== undefined) {
       const before = edit[0] === 0 ? null : sender.at(edit[0] - 1);
-      let id: ElementId;
-      // Try to extend before's bunch, so that it will be compressed.
-      if (
-        before !== null &&
-        sender.maxCounter(before.bunchId) === before.counter
-      ) {
-        id = { bunchId: before.bunchId, counter: before.counter + 1 };
-      } else {
-        // id = { bunchId: uuidv4(), counter: 0 };
-        id = { bunchId: nextBunchId(), counter: 0 };
-      }
+      const id = idGenerator.generateAfter(before);
 
       sender = sender.insertAfter(before, id);
 


### PR DESCRIPTION
Closed #16 . Also bumped the Actions version and added build and benchmark tests.